### PR TITLE
Implemented the context menu for torrents

### DIFF
--- a/src/picotorrent.h
+++ b/src/picotorrent.h
@@ -39,6 +39,8 @@ private:
     void SaveTorrents();
 
     void SaveTorrentFile(boost::shared_ptr<const libtorrent::torrent_info> file);
+    void DeleteTorrentFile(const libtorrent::sha1_hash& hash);
+    void DeleteResumeData(const libtorrent::sha1_hash& hash);
 
     int numOutstandingResumeData = 0;
 

--- a/src/ui/mainframe.h
+++ b/src/ui/mainframe.h
@@ -4,6 +4,7 @@
 #include <libtorrent/session_handle.hpp>
 #include <libtorrent/torrent_handle.hpp>
 #include <map>
+#include <vector>
 #include <wx/frame.h>
 #include <wx/panel.h>
 
@@ -16,11 +17,14 @@ public:
     MainFrame(libtorrent::session_handle& session);
 
     void AddTorrent(const libtorrent::torrent_status& status);
-    void UpdateTorrent(const libtorrent::torrent_status& status);
+    void UpdateTorrents(std::vector<libtorrent::torrent_status> status);
+    void RemoveTorrent(const libtorrent::sha1_hash& hash);
 
 protected:
     void OnFileAddTorrent(wxCommandEvent& event);
     void OnFileExit(wxCommandEvent& event);
+    void OnTorrentContextMenu(wxCommandEvent& event);
+
     void OnSize(wxSizeEvent& event);
 
     void OnListItemActivated(wxListEvent& event);
@@ -28,18 +32,30 @@ protected:
 
     void OnTorrentDetailsFrameClose(wxCloseEvent& event, libtorrent::sha1_hash hash);
 
+    void ShowDetails(const libtorrent::sha1_hash& hash);
+
     enum
     {
-        ptID_FILE_ADD_TORRENT,
-        ptID_FILE_EXIT = wxID_EXIT
+        ptID_MAINFRAME = 5999,
+
+        ptID_FILE_ADD_TORRENT = 4000,
+        ptID_FILE_EXIT = wxID_EXIT,
+
+        ptID_TORRENT_RESUME = 6000,
+        ptID_TORRENT_PAUSE = 6001,
+        ptID_TORRENT_AUTO_MANAGE_TOGGLE = 6002,
+        ptID_TORRENT_FORCE_RECHECK = 6003,
+        ptID_TORRENT_MOVE = 6004,
+        ptID_TORRENT_REMOVE = 6005,
+        ptID_TORRENT_REMOVE_DATA = 6006,
+        ptID_TORRENT_SHOW_DETAILS = 6007
     };
 
 private:
     wxString GetTorrentState(const libtorrent::torrent_status& status);
 
     libtorrent::session_handle& session_;
-    std::map<libtorrent::sha1_hash, long> items_;
-    std::map<long, libtorrent::sha1_hash> itemsReverse_;
+    std::map<libtorrent::sha1_hash, libtorrent::torrent_status> torrents_;
     std::map<libtorrent::sha1_hash, TorrentDetailsFrame*> details_;
 
     TorrentListCtrl* torrentList_;


### PR DESCRIPTION
This implements the context menu when right-clicking torrents in the list view.

It also rewrites how we add and update torrents in the list view in order to support removing torrents, since the index changes for torrents when one is removed at the bottom of the list.