### PR TITLE
Treat warnings as errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ set(PICOTORRENT_SOURCES
     src/ui/scaler
 )
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4714 /W4 /WX")
+
 include_directories(${includes})
 
 link_directories(

--- a/src/controllers/addtorrentcontroller.cpp
+++ b/src/controllers/addtorrentcontroller.cpp
@@ -1,8 +1,10 @@
 #include "addtorrentcontroller.h"
 
+#pragma warning(disable: 4005 4245 4267 4800)
 #include <libtorrent/add_torrent_params.hpp>
 #include <libtorrent/session_handle.hpp>
 #include <libtorrent/torrent_info.hpp>
+#pragma warning(default: 4005 4245 4267 4800)
 
 #include "../util.h"
 
@@ -94,7 +96,7 @@ std::wstring AddTorrentController::GetSavePath(uint64_t index)
     return Util::ToWideString(path);
 }
 
-uint64_t AddTorrentController::GetFileCount(uint64_t index)
+int AddTorrentController::GetFileCount(uint64_t index)
 {
     return params_[index].ti->num_files();
 }
@@ -111,7 +113,7 @@ std::wstring AddTorrentController::GetFileSize(uint64_t index, int fileIndex)
     return Util::ToFileSize(size);
 }
 
-int AddTorrentController::GetFilePriority(uint64_t index, int fileIndex)
+uint8_t AddTorrentController::GetFilePriority(uint64_t index, int fileIndex)
 {
     lt::add_torrent_params& p = params_[index];
 
@@ -128,7 +130,7 @@ void AddTorrentController::SetFileName(int64_t index, int fileIndex, const std::
     params_[index].ti->rename_file(fileIndex, Util::ToString(name));
 }
 
-void AddTorrentController::SetFilePriority(int64_t index, int fileIndex, int priority)
+void AddTorrentController::SetFilePriority(int64_t index, int fileIndex, uint8_t priority)
 {
     lt::add_torrent_params& p = params_[index];
 

--- a/src/controllers/addtorrentcontroller.h
+++ b/src/controllers/addtorrentcontroller.h
@@ -27,13 +27,13 @@ namespace pico
         std::wstring GetCreator(uint64_t index);
         std::wstring GetSavePath(uint64_t index);
 
-        uint64_t GetFileCount(uint64_t index);
+        int GetFileCount(uint64_t index);
         std::wstring GetFileName(uint64_t index, int fileIndex);
         std::wstring GetFileSize(uint64_t index, int fileIndex);
-        int GetFilePriority(uint64_t index, int fileIndex);
+        uint8_t GetFilePriority(uint64_t index, int fileIndex);
 
         void SetFileName(int64_t index, int fileIndex, const std::wstring& name);
-        void SetFilePriority(int64_t index, int fileIndex, int priority);
+        void SetFilePriority(int64_t index, int fileIndex, uint8_t priority);
         void SetSavePath(uint64_t index, const std::wstring& path);
 
     private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,8 +5,8 @@
 
 int WINAPI wWinMain(
     _In_     HINSTANCE hInstance,
-    _In_opt_ HINSTANCE hPrevInstance,
-    _In_     LPWSTR    lpCmdLine,
+    _In_opt_ HINSTANCE,
+    _In_     LPWSTR,
     _In_     int       nCmdShow)
 {
     pico::Logging::Init();

--- a/src/picotorrent.cpp
+++ b/src/picotorrent.cpp
@@ -1,5 +1,6 @@
 #include "picotorrent.h"
 
+#pragma warning(disable: 4005 4245 4267 4800)
 #include <boost/filesystem.hpp>
 #include <boost/log/trivial.hpp>
 #include <libtorrent/alert_types.hpp>
@@ -7,6 +8,7 @@
 #include <libtorrent/create_torrent.hpp>
 #include <libtorrent/session.hpp>
 #include <libtorrent/session_stats.hpp>
+#pragma warning(default: 4005 4245 4267 4800)
 
 #include "path.h"
 #include "statemanager.h"
@@ -27,9 +29,7 @@ PicoTorrent::PicoTorrent(HINSTANCE hInstance)
 
     SetProcessDPIAware();
 
-    HRESULT hRes = _Module.Init(NULL, hInstance);
-    ATLASSERT(SUCCEEDED(hRes));
-
+    _Module.Init(NULL, hInstance);
     _Module.AddMessageLoop(&loop_);
 
     lt::settings_pack settings;;
@@ -87,7 +87,7 @@ bool PicoTorrent::Init()
         LPWSTR cmd = GetCommandLine();
 
         COPYDATASTRUCT cds;
-        cds.cbData = sizeof(TCHAR) * (_tcslen(cmd) + 1);
+        cds.cbData = (DWORD)(sizeof(TCHAR) * (_tcslen(cmd) + 1));
         cds.dwData = 1;
         cds.lpData = cmd;
 
@@ -155,7 +155,9 @@ void PicoTorrent::HandleAlert(lt::alert* alert)
         }
 
         SaveTorrent(a->handle.torrent_file());
-        frame_->AddTorrent(a->handle.status());
+
+        lt::torrent_status st = a->handle.status();
+        frame_->AddTorrent(st);
         break;
     }
 
@@ -168,8 +170,6 @@ void PicoTorrent::HandleAlert(lt::alert* alert)
 
     case lt::session_stats_alert::alert_type:
     {
-        lt::session_stats_alert* a = lt::alert_cast<lt::session_stats_alert>(alert);
-        
         break;
     }
 

--- a/src/statemanager.cpp
+++ b/src/statemanager.cpp
@@ -1,10 +1,12 @@
 #include "statemanager.h"
 
+#pragma warning(disable: 4005 4245 4267 4800)
 #include <boost/filesystem.hpp>
 #include <boost/log/trivial.hpp>
 #include <libtorrent/alert_types.hpp>
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/session_handle.hpp>
+#pragma warning(default: 4005 4245 4267 4800)
 
 #include "path.h"
 #include "io/file.h"
@@ -158,7 +160,7 @@ void StateManager::SaveTorrents()
     int numPaused = 0;
 
     std::vector<lt::torrent_status> temp;
-    session_.get_torrent_status(&temp, [](const lt::torrent_status& status) { return true; }, 0);
+    session_.get_torrent_status(&temp, [](const lt::torrent_status&) { return true; }, 0);
 
     for (lt::torrent_status& status : temp)
     {

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -14,6 +14,7 @@
                             language='*'\"")
 
 #include <windows.h>
+#pragma warning(disable: 4458 4838)
 #include <atlbase.h>
 #include <atlapp.h>
 
@@ -24,5 +25,6 @@ extern CAppModule _Module;
 #include <atlframe.h>
 #include <atlstr.h>
 #include <atlcrack.h>
+#pragma warning(default: 4458 4838)
 
 #include "resources.h"

--- a/src/ui/addtorrentdialog.cpp
+++ b/src/ui/addtorrentdialog.cpp
@@ -51,12 +51,12 @@ LRESULT AddTorrentDialog::OnClose(WORD /*wNotifyCode*/, WORD wID, HWND /*hWndCtl
     return TRUE;
 }
 
-void AddTorrentDialog::OnFinalMessage(HWND hWnd)
+void AddTorrentDialog::OnFinalMessage(HWND)
 {
     delete this;
 }
 
-LRESULT AddTorrentDialog::OnTorrentSelected(WORD /*wNotifyCode*/, WORD wID, HWND /*hWndCtl*/, BOOL& /*bHandled*/)
+LRESULT AddTorrentDialog::OnTorrentSelected(WORD /*wNotifyCode*/, WORD, HWND /*hWndCtl*/, BOOL& /*bHandled*/)
 {
     CComboBox torrents = (CComboBox)GetDlgItem(ID_ADDTORRENT_TORRENTS);
     ShowTorrent(torrents.GetCurSel());
@@ -83,7 +83,7 @@ void AddTorrentDialog::ShowTorrent(uint64_t index)
     files.DeleteAllItems();
     files.SetExtendedListViewStyle(LVS_EX_FULLROWSELECT);
 
-    for (uint64_t i = 0; i < controller_->GetFileCount(index); i++)
+    for (int i = 0; i < controller_->GetFileCount(index); i++)
     {
         std::wstring fileName = controller_->GetFileName(index, i);
         std::wstring fileSize = controller_->GetFileSize(index, i);
@@ -95,7 +95,7 @@ void AddTorrentDialog::ShowTorrent(uint64_t index)
     }
 }
 
-LRESULT AddTorrentDialog::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+LRESULT AddTorrentDialog::OnContextMenu(UINT, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     CListViewCtrl files = (CListViewCtrl)GetDlgItem(ID_ADDTORRENT_FILES);
     
@@ -140,7 +140,7 @@ LRESULT AddTorrentDialog::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam,
     return FALSE;
 }
 
-LRESULT AddTorrentDialog::OnRenameFile(WORD /*wNotifyCode*/, WORD wID, HWND /*hWndCtl*/, BOOL& /*bHandled*/)
+LRESULT AddTorrentDialog::OnRenameFile(WORD /*wNotifyCode*/, WORD, HWND /*hWndCtl*/, BOOL& /*bHandled*/)
 {
     CComboBox torrents = (CComboBox)GetDlgItem(ID_ADDTORRENT_TORRENTS);
     CListViewCtrl files = (CListViewCtrl)GetDlgItem(ID_ADDTORRENT_FILES);
@@ -197,7 +197,7 @@ LRESULT AddTorrentDialog::OnPrioritizeFile(WORD /*wNotifyCode*/, WORD wID, HWND 
     return FALSE;
 }
 
-LRESULT AddTorrentDialog::BrowseSavePath(WORD /*wNotifyCode*/, WORD wID, HWND /*hWndCtl*/, BOOL& /*bHandled*/)
+LRESULT AddTorrentDialog::BrowseSavePath(WORD /*wNotifyCode*/, WORD, HWND /*hWndCtl*/, BOOL& /*bHandled*/)
 {
     CFolderDialog dlg;
 

--- a/src/ui/mainframe.cpp
+++ b/src/ui/mainframe.cpp
@@ -1,10 +1,12 @@
 #include "mainframe.h"
 
+#pragma warning(disable: 4005 4245 4267 4800)
 #include <boost/filesystem.hpp>
 #include <boost/log/trivial.hpp>
 #include <libtorrent/add_torrent_params.hpp>
 #include <libtorrent/session_handle.hpp>
 #include <libtorrent/torrent_handle.hpp>
+#pragma warning(default: 4005 4245 4267 4800)
 #include <shellapi.h>
 
 #include "addtorrentdialog.h"
@@ -48,7 +50,7 @@ void MainFrame::UpdateTorrent(lt::torrent_status& status)
     torrentsList_.SetItemText(idx, 4, Util::ToSpeed(status.upload_payload_rate).c_str());
 }
 
-LRESULT MainFrame::OnCopyData(HWND hWnd, PCOPYDATASTRUCT pCopyData)
+LRESULT MainFrame::OnCopyData(HWND, PCOPYDATASTRUCT pCopyData)
 {
     if (pCopyData->dwData == 1)
     {
@@ -96,7 +98,7 @@ LRESULT MainFrame::OnDestroy()
     return 0;
 }
 
-LRESULT MainFrame::OnTimer(UINT timerID)
+LRESULT MainFrame::OnTimer(UINT_PTR)
 {
     session_.post_dht_stats();
     session_.post_session_stats();
@@ -105,9 +107,9 @@ LRESULT MainFrame::OnTimer(UINT timerID)
     return FALSE;
 }
 
-LRESULT MainFrame::OnFileAddTorrent(UINT uNotifyCode, int nID, CWindow wndCtl)
+LRESULT MainFrame::OnFileAddTorrent(UINT, int, CWindow)
 {
-    LPCTSTR files =
+    LPCTSTR filter =
         L"Torrent Files (*.torrent)\0*.torrent\0"
         L"All Files (*.*)\0*.*\0\0";
 
@@ -115,7 +117,7 @@ LRESULT MainFrame::OnFileAddTorrent(UINT uNotifyCode, int nID, CWindow wndCtl)
         NULL,
         NULL,
         OFN_HIDEREADONLY | OFN_ALLOWMULTISELECT | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR,
-        files,
+        filter,
         m_hWnd);
 
     TCHAR buffer[65535] = { 0 };

--- a/src/ui/mainframe.h
+++ b/src/ui/mainframe.h
@@ -9,7 +9,7 @@
 namespace libtorrent
 {
     struct session_handle;
-    struct sha1_hash;
+    class sha1_hash;
     struct torrent_status;
 }
 
@@ -29,7 +29,7 @@ namespace pico
         LRESULT OnCopyData(HWND, PCOPYDATASTRUCT);
         LRESULT OnCreate(LPCREATESTRUCT);
         LRESULT OnDestroy();
-        LRESULT OnTimer(UINT);
+        LRESULT OnTimer(UINT_PTR);
         LRESULT OnFileAddTorrent(UINT uNotifyCode, int nID, CWindow wndCtl);
 
         void ParseCommandLine(std::wstring cmdLine);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,8 +2,10 @@
 
 #include <shlwapi.h>
 #define TORRENT_WINDOWS
+#pragma warning(disable: 4005 4245 4267)
 #include <libtorrent/torrent_handle.hpp>
 #include <libtorrent/utf8.hpp>
+#pragma warning(default: 4005 4245 4267)
 
 namespace lt = libtorrent;
 using namespace pico;


### PR DESCRIPTION
Made PicoTorrent compile without errors when turning on `/W4` and `/WX`.