### PR TITLE
Allow PicoTorrent to work with magnet links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(OPENSSL_ROOT    $ENV{OPENSSL_ROOT})
 
 set(PICOAPP_SOURCES
     src/app/application
+    src/app/command_line
     src/app/message_loop
     src/app/controllers/add_torrent_controller
     src/app/controllers/move_torrent_controller

--- a/include/picotorrent/app/command_line.hpp
+++ b/include/picotorrent/app/command_line.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <picotorrent/filesystem/path.hpp>
+#include <string>
+#include <vector>
+
+namespace picotorrent
+{
+namespace app
+{
+    class command_line
+    {
+    public:
+        static command_line parse(const std::wstring &cmd);
+
+        std::vector<filesystem::path> files() const;
+        std::vector<std::wstring> magnet_links() const;
+
+    private:
+        std::vector<std::wstring> magnets_;
+        std::vector<filesystem::path> files_;
+    };
+}
+}

--- a/include/picotorrent/app/controllers/add_torrent_controller.hpp
+++ b/include/picotorrent/app/controllers/add_torrent_controller.hpp
@@ -20,6 +20,8 @@ namespace ui
 }
 namespace app
 {
+    class command_line;
+
 namespace controllers
 {
     class add_torrent_controller
@@ -28,9 +30,10 @@ namespace controllers
         add_torrent_controller(const std::shared_ptr<core::session> &sess, const std::shared_ptr<ui::main_window> &wnd_ptr);
 
         void execute();
-        void execute(const std::vector<filesystem::path> &files);
+        void execute(const command_line &cmd);
 
     private:
+        void add_files(const std::vector<filesystem::path> &files, const std::wstring &save_path);
         std::wstring get_save_path();
 
         std::shared_ptr<core::session> sess_;

--- a/include/picotorrent/core/add_request.hpp
+++ b/include/picotorrent/core/add_request.hpp
@@ -25,8 +25,10 @@ namespace core
 
         std::wstring save_path();
         std::shared_ptr<torrent_file> torrent_file();
+        std::wstring url();
         void set_save_path(const std::wstring &path);
         void set_torrent_file(const std::shared_ptr<core::torrent_file> &file);
+        void set_url(const std::wstring &url);
 
     private:
         std::unique_ptr<libtorrent::add_torrent_params> params_;

--- a/installer/PicoTorrent.wxs
+++ b/installer/PicoTorrent.wxs
@@ -133,6 +133,28 @@
                                 <MIME Advertise="yes" ContentType="application/x-bittorrent" Default="yes" />
                             </Extension>
                         </ProgId>
+
+                        <!-- Magnet URI schema registration -->
+                        <RegistryValue Root="HKCR"
+                                       Key="magnet"
+                                       Value="PicoTorrent magnet link"
+                                       Type="string" />
+
+                        <RegistryValue Root="HKCR"
+                                       Key="magnet"
+                                       Name="URL Protocol"
+                                       Value=""
+                                       Type="string" />
+
+                        <RegistryValue Root="HKCR"
+                                       Key="magnet\DefaultIcon"
+                                       Value="[INSTALLDIR]PicoTorrent.exe,0"
+                                       Type="string" />
+
+                        <RegistryValue Root="HKCR"
+                                       Key="magnet\shell\open\command"
+                                       Value="&quot;[INSTALLDIR]PicoTorrent.exe&quot; &quot;%1&quot;"
+                                       Type="string" />
                     </Component>
                 </Directory>
             </Directory>

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -1,5 +1,6 @@
 #include <picotorrent/app/application.hpp>
 
+#include <picotorrent/app/command_line.hpp>
 #include <picotorrent/app/message_loop.hpp>
 #include <picotorrent/app/controllers/add_torrent_controller.hpp>
 #include <picotorrent/app/controllers/torrent_context_menu_controller.hpp>
@@ -20,6 +21,7 @@ namespace core = picotorrent::core;
 namespace fs = picotorrent::filesystem;
 namespace ui = picotorrent::ui;
 using picotorrent::app::application;
+using picotorrent::app::command_line;
 using picotorrent::logging::log;
 
 application::application()
@@ -116,18 +118,10 @@ int application::run(const std::wstring &args)
 
 void application::on_command_line_args(const std::wstring &args)
 {
-    int argv;
-    LPWSTR *argc = CommandLineToArgvW(args.c_str(), &argv);
-
-    std::vector<fs::path> files;
-
-    for (int i = 0; i < argv; i++)
-    {
-        files.push_back(argc[i]);
-    }
+    command_line cmd = command_line::parse(args);
 
     controllers::add_torrent_controller add_controller(sess_, main_window_);
-    add_controller.execute(files);
+    add_controller.execute(cmd);
 }
 
 void application::on_file_add_torrent()

--- a/src/app/command_line.cpp
+++ b/src/app/command_line.cpp
@@ -1,0 +1,45 @@
+#include <picotorrent/app/command_line.hpp>
+
+#include <windows.h>
+#include <shellapi.h>
+
+using picotorrent::app::command_line;
+
+command_line command_line::parse(const std::wstring &cmd)
+{
+    int argv;
+    LPWSTR *argc = CommandLineToArgvW(cmd.c_str(), &argv);
+
+    command_line cl;
+
+    for (int i = 0; i < argv; i++)
+    {
+        std::wstring arg(argc[i]);
+
+        if (arg.empty())
+        {
+            continue;
+        }
+
+        if (arg.substr(0, 10) == L"magnet:?xt")
+        {
+            cl.magnets_.push_back(arg);
+        }
+        else
+        {
+            cl.files_.push_back(arg);
+        }
+    }
+
+    return cl;
+}
+
+std::vector<picotorrent::filesystem::path> command_line::files() const
+{
+    return files_;
+}
+
+std::vector<std::wstring> command_line::magnet_links() const
+{
+    return magnets_;
+}

--- a/src/core/add_request.cpp
+++ b/src/core/add_request.cpp
@@ -36,6 +36,11 @@ std::shared_ptr<picotorrent::core::torrent_file> add_request::torrent_file()
     return std::make_shared<picotorrent::core::torrent_file>(*params_->ti);
 }
 
+std::wstring add_request::url()
+{
+    return to_wstring(params_->url);
+}
+
 void add_request::set_save_path(const std::wstring &path)
 {
     params_->save_path = to_string(path);
@@ -44,4 +49,9 @@ void add_request::set_save_path(const std::wstring &path)
 void add_request::set_torrent_file(const std::shared_ptr<picotorrent::core::torrent_file> &file)
 {
     params_->ti = boost::make_shared<lt::torrent_info>(*file->info_);
+}
+
+void add_request::set_url(const std::wstring &url)
+{
+    params_->url = to_string(url);
 }


### PR DESCRIPTION
- Respond to magnet URIs in browsers.
- Keeps state for a magnet link which have not fully received
  metadata yet.