### PR TITLE
Fix for Add torrent bug.

### DIFF
--- a/src/app/controllers/add_torrent_controller.cpp
+++ b/src/app/controllers/add_torrent_controller.cpp
@@ -39,6 +39,11 @@ void add_torrent_controller::execute()
     dlg.set_guid(DLG_OPEN);
     dlg.show(wnd_->handle());
 
+    if (dlg.get_paths().empty())
+    {
+        return;
+    }
+
     add_files(dlg.get_paths(), get_save_path());
 }
 


### PR DESCRIPTION
Don't show save path selection when cancelling the Open torrent dialog.