### PR TITLE
Add ability to always use default save path when adding torrents.

### DIFF
--- a/include/picotorrent/config/configuration.hpp
+++ b/include/picotorrent/config/configuration.hpp
@@ -32,6 +32,9 @@ namespace config
         int listen_port();
         void set_listen_port(int port);
 
+        bool prompt_for_save_path();
+        void set_prompt_for_save_path(bool value);
+
         int stop_tracker_timeout();
 
     private:

--- a/include/picotorrent/ui/preferences_dialog.hpp
+++ b/include/picotorrent/ui/preferences_dialog.hpp
@@ -14,9 +14,11 @@ namespace ui
         preferences_dialog(HWND hParent);
 
         int do_modal();
+        bool get_checked(int controlId);
         std::wstring get_text(int controlId);
         void on_ok(const std::function<void(preferences_dialog&)> &callback);
         void on_init(const std::function<void(preferences_dialog&)> &callback);
+        void set_checked(int controlId, bool checked);
         void set_text(int controlId, const std::wstring &text);
 
     private:

--- a/include/picotorrent/ui/resources.hpp
+++ b/include/picotorrent/ui/resources.hpp
@@ -15,6 +15,7 @@
 // Preferences dialog
 #define ID_PREFS_DEFSAVEPATH 9101
 #define ID_PREFS_LISTENPORT 9102
+#define ID_PREFS_PROMPTFORSAVEPATH 9103
 
 // Torrent context menu
 #define IDR_TORRENT_CONTEXT_MENU 4100

--- a/src/app/controllers/add_torrent_controller.cpp
+++ b/src/app/controllers/add_torrent_controller.cpp
@@ -103,6 +103,11 @@ std::wstring add_torrent_controller::get_save_path()
 {
     configuration &cfg = configuration::instance();
 
+    if (!cfg.prompt_for_save_path())
+    {
+        return cfg.default_save_path();
+    }
+
     ui::open_file_dialog dlg;
     dlg.set_guid(DLG_SAVE);
     dlg.set_folder(cfg.default_save_path());

--- a/src/app/controllers/view_preferences_controller.cpp
+++ b/src/app/controllers/view_preferences_controller.cpp
@@ -30,6 +30,7 @@ void view_preferences_controller::init_dlg(preferences_dialog &dlg)
 
     dlg.set_text(ID_PREFS_DEFSAVEPATH, cfg.default_save_path());
     dlg.set_text(ID_PREFS_LISTENPORT, std::to_wstring(cfg.listen_port()));
+    dlg.set_checked(ID_PREFS_PROMPTFORSAVEPATH, cfg.prompt_for_save_path());
 }
 
 void view_preferences_controller::ok_dlg(preferences_dialog &dlg)
@@ -39,7 +40,9 @@ void view_preferences_controller::ok_dlg(preferences_dialog &dlg)
     std::wstring savePath = dlg.get_text(ID_PREFS_DEFSAVEPATH);
     std::wstring listenPortText = dlg.get_text(ID_PREFS_LISTENPORT);
     int listenPort = std::stoi(listenPortText);
+    bool promptForSavePath = dlg.get_checked(ID_PREFS_PROMPTFORSAVEPATH);
 
     cfg.set_default_save_path(savePath);
     cfg.set_listen_port(listenPort);
+    cfg.set_prompt_for_save_path(promptForSavePath);
 }

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -59,6 +59,16 @@ void configuration::set_listen_port(int port)
     set("listen_port", port);
 }
 
+bool configuration::prompt_for_save_path()
+{
+    return get_or_default("prompt_for_save_path", true);
+}
+
+void configuration::set_prompt_for_save_path(bool value)
+{
+    set("prompt_for_save_path", value);
+}
+
 int configuration::stop_tracker_timeout()
 {
     return get_or_default("stop_tracker_timeout", 1);

--- a/src/resources/preferences_dialog.rc
+++ b/src/resources/preferences_dialog.rc
@@ -1,17 +1,23 @@
 #include <picotorrent/ui/resources.hpp>
 #include <windows.h>
 
-IDD_PREFERENCES DIALOGEX 0, 0, 200, 59
+IDD_PREFERENCES DIALOGEX 0, 0, 200, 109
 CAPTION "Preferences"
 FONT 8, "MS Shell Dlg"
 STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU | WS_VISIBLE
 {
-    LTEXT "Default save path", -1, 5, 5, 80, 10
-    EDITTEXT ID_PREFS_DEFSAVEPATH, 90, 5, 105, 11
+    GROUPBOX "Connection", -1, 5, 5, 190, 30
 
-    LTEXT "Listen port", -1, 5, 20, 80, 10
-    EDITTEXT ID_PREFS_LISTENPORT, 90, 20, 25, 11
+    LTEXT "Listen port", -1, 10, 20, 80, 10
+    EDITTEXT ID_PREFS_LISTENPORT, 90, 19, 25, 11
 
-    CONTROL "", -1, "Static", SS_ETCHEDHORZ, 5, 35, 190, 1
-    DEFPUSHBUTTON "OK", IDOK, 145, 40, 50, 14
+    GROUPBOX "Downloads", -1, 5, 40, 190, 45
+
+    LTEXT "Default save path", -1, 10, 55, 80, 10
+    EDITTEXT ID_PREFS_DEFSAVEPATH, 90, 54, 100, 11
+
+    LTEXT "Prompt for save path", -1, 10, 70, 80, 10
+    CHECKBOX "", ID_PREFS_PROMPTFORSAVEPATH, 90, 69, 15, 11
+
+    DEFPUSHBUTTON "OK", IDOK, 145, 90, 50, 14
 }

--- a/src/ui/preferences_dialog.cpp
+++ b/src/ui/preferences_dialog.cpp
@@ -21,6 +21,11 @@ int preferences_dialog::do_modal()
     return (int)result;
 }
 
+bool preferences_dialog::get_checked(int controlId)
+{
+    return IsDlgButtonChecked(hWnd_, controlId);
+}
+
 std::wstring preferences_dialog::get_text(int controlId)
 {
     HWND hItem = GetDlgItem(hWnd_, controlId);
@@ -39,6 +44,11 @@ void preferences_dialog::on_init(const std::function<void(preferences_dialog&)> 
 void preferences_dialog::on_ok(const std::function<void(preferences_dialog&)> &callback)
 {
     ok_cb_ = callback;
+}
+
+void preferences_dialog::set_checked(int controlId, bool checked)
+{
+    CheckDlgButton(hWnd_, controlId, checked ? BST_CHECKED : BST_UNCHECKED);
 }
 
 void preferences_dialog::set_text(int controlId, const std::wstring &text)
@@ -65,6 +75,12 @@ INT_PTR preferences_dialog::dlg_proc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPA
 
             EndDialog(hwndDlg, wParam);
             return TRUE;
+        }
+        
+        case ID_PREFS_PROMPTFORSAVEPATH:
+        {
+            set_checked(ID_PREFS_PROMPTFORSAVEPATH, !get_checked(ID_PREFS_PROMPTFORSAVEPATH));
+            break;
         }
         }
 


### PR DESCRIPTION
To streamline experience, this adds an option to always use the default save path when adding torrents. This means you can click magnet links (or add torrent files) and they start downloading in PicoTorrent without prompting for further input.

<img width="302" alt="picotorrent_preferences1" src="https://cloud.githubusercontent.com/assets/1491824/11194117/9cfc9b7a-8caa-11e5-9631-0ea4ff125803.png">
