### PR TITLE
Add an ETA column to the transfer list

### DIFF
--- a/include/picotorrent/core/torrent.hpp
+++ b/include/picotorrent/core/torrent.hpp
@@ -32,6 +32,7 @@ namespace core
         torrent(const torrent &that) = delete;
 
         int download_rate();
+		int eta() const;
         bool has_error() const;
         std::shared_ptr<hash> info_hash();
         bool is_checking() const;

--- a/include/picotorrent/ui/sort.hpp
+++ b/include/picotorrent/ui/sort.hpp
@@ -14,6 +14,7 @@ namespace ui
         typedef std::function<bool(const torrent_list_item&, const torrent_list_item&)> sort_func_t;
 
         static sort_func_t by_download_rate(bool ascending);
+		static sort_func_t by_eta(bool ascending);
         static sort_func_t by_name(bool ascending);
         static sort_func_t by_progress(bool ascending);
         static sort_func_t by_queue_position(bool ascending);

--- a/include/picotorrent/ui/torrent_list_item.hpp
+++ b/include/picotorrent/ui/torrent_list_item.hpp
@@ -21,6 +21,8 @@ namespace ui
 
         int download_rate() const;
         std::wstring download_rate_str() const;
+		int eta() const;
+		std::wstring eta_str() const;
         std::wstring name() const;
         float progress() const;
         std::wstring progress_str() const;

--- a/include/picotorrent/ui/torrent_list_view.hpp
+++ b/include/picotorrent/ui/torrent_list_view.hpp
@@ -11,8 +11,9 @@
 #define COL_SIZE 2
 #define COL_STATE 3
 #define COL_PROGRESS 4
-#define COL_DOWNLOAD_RATE 5
-#define COL_UPLOAD_RATE 6
+#define COL_ETA 5
+#define COL_DOWNLOAD_RATE 6
+#define COL_UPLOAD_RATE 7
 
 namespace picotorrent
 {

--- a/src/core/torrent.cpp
+++ b/src/core/torrent.cpp
@@ -21,6 +21,23 @@ int torrent::download_rate()
     return status_->download_payload_rate;
 }
 
+int torrent::eta() const
+{
+	if (is_paused())
+	{
+		return -1;
+	}
+
+	int64_t remaining = status_->total_wanted - status_->total_wanted_done;
+
+	if (remaining > 0 && status_->download_payload_rate > 0)
+	{
+		return remaining / status_->download_payload_rate;
+	}
+
+	return -1;
+}
+
 bool torrent::has_error() const
 {
     return status_->paused && status_->errc;

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -243,6 +243,7 @@ LRESULT main_window::wnd_proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
         list_view_->add_column(TEXT("Size"), scaler::x(80), LVCFMT_RIGHT);
         list_view_->add_column(TEXT("Status"), scaler::x(120), LVCFMT_LEFT);
         list_view_->add_column(TEXT("Progress"), scaler::x(100), LVCFMT_LEFT);
+		list_view_->add_column(TEXT("ETA"), scaler::x(80), LVCFMT_RIGHT);
         list_view_->add_column(TEXT("DL"), scaler::x(80), LVCFMT_RIGHT);
         list_view_->add_column(TEXT("UL"), scaler::x(80), LVCFMT_RIGHT);
 
@@ -326,6 +327,14 @@ LRESULT main_window::wnd_proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
                     std::sort(items_.begin(), items_.end(), sort::by_progress(isAscending));
                 };
                 break;
+			case COL_ETA:
+			{
+				sort_items_ = [this, isAscending]()
+				{
+					std::sort(items_.begin(), items_.end(), sort::by_eta(isAscending));
+				};
+				break;
+			}
             case COL_DOWNLOAD_RATE:
                 sort_items_ = [this, isAscending]()
                 {

--- a/src/ui/sort.cpp
+++ b/src/ui/sort.cpp
@@ -18,6 +18,19 @@ sort::sort_func_t sort::by_download_rate(bool ascending)
     };
 }
 
+sort::sort_func_t sort::by_eta(bool ascending)
+{
+	return [ascending](const torrent_list_item &lhs, const torrent_list_item &rhs)
+	{
+		if (ascending)
+		{
+			return lhs.eta() < rhs.eta();
+		}
+
+		return lhs.eta() > rhs.eta();
+	};
+}
+
 sort::sort_func_t sort::by_name(bool ascending)
 {
     return [ascending](const torrent_list_item &lhs, const torrent_list_item &rhs)

--- a/src/ui/torrent_list_item.cpp
+++ b/src/ui/torrent_list_item.cpp
@@ -30,6 +30,56 @@ std::wstring torrent_list_item::download_rate_str() const
     return get_speed(torrent_->download_rate());
 }
 
+int torrent_list_item::eta() const
+{
+	return torrent_->eta();
+}
+
+std::wstring torrent_list_item::eta_str() const
+{
+	int seconds = torrent_->eta();
+
+	if (seconds < 0)
+	{
+		return L"-";
+	}
+
+	if(seconds == 0)
+	{
+		return L"0";
+	}
+
+	if (seconds < 60)
+	{
+		return L"< 1m";
+	}
+
+	int minutes = seconds / 60;
+
+	if (minutes < 60)
+	{
+		return std::to_wstring(minutes) + L"m";
+	}
+
+	int hours = minutes / 60;
+	minutes = minutes - hours * 60;
+
+	if (hours < 24)
+	{
+		return std::to_wstring(hours) + L"h " + std::to_wstring(minutes) + L"m";
+	}
+
+	int days = hours / 24;
+	hours = hours - days * 24;
+
+	if (days < 100)
+	{
+		return std::to_wstring(days) + L"d " + std::to_wstring(hours) + L"h";
+	}
+
+	return L"-";
+}
+
 std::wstring torrent_list_item::name() const
 {
     return to_wstring(torrent_->name());

--- a/src/ui/torrent_list_view.cpp
+++ b/src/ui/torrent_list_view.cpp
@@ -235,6 +235,11 @@ void torrent_list_view::on_getdispinfo(NMLVDISPINFO* inf, const torrent_list_ite
             StringCchCopy(inf->item.pszText, inf->item.cchTextMax, item.state_str().c_str());
             break;
         }
+		case COL_ETA:
+		{
+			StringCchCopy(inf->item.pszText, inf->item.cchTextMax, item.eta_str().c_str());
+			break;
+		}
         case COL_DOWNLOAD_RATE:
         case COL_UPLOAD_RATE:
         {


### PR DESCRIPTION
Adds a sortable ETA column to the transfer list.

![picotorrent_eta1](https://cloud.githubusercontent.com/assets/1491824/11725016/aea71f14-9f77-11e5-8d7d-9bf79d9dd1d9.png)
