### PR TITLE
Load session settings

### DIFF
--- a/include/picotorrent/app/controllers/view_preferences_controller.hpp
+++ b/include/picotorrent/app/controllers/view_preferences_controller.hpp
@@ -5,6 +5,10 @@
 
 namespace picotorrent
 {
+namespace core
+{
+    class session;
+}
 namespace ui
 {
     class main_window;
@@ -26,7 +30,7 @@ namespace controllers
     class view_preferences_controller
     {
     public:
-        view_preferences_controller(const std::shared_ptr<ui::main_window> &wnd);
+        view_preferences_controller(const std::shared_ptr<core::session> &sess, const std::shared_ptr<ui::main_window> &wnd);
         ~view_preferences_controller();
         void execute();
 
@@ -39,6 +43,7 @@ namespace controllers
         void on_connection_proxy_type_changed(int type);
 
     private:
+        std::shared_ptr<core::session> sess_;
         std::shared_ptr<ui::main_window> wnd_;
         std::unique_ptr<ui::property_sheets::preferences::connection_page> conn_page_;
         std::unique_ptr<ui::property_sheets::preferences::downloads_page> dl_page_;

--- a/include/picotorrent/core/session.hpp
+++ b/include/picotorrent/core/session.hpp
@@ -10,6 +10,7 @@ namespace libtorrent
 {
     class session;
     class sha1_hash;
+    struct settings_pack;
     class torrent_info;
 }
 
@@ -32,6 +33,7 @@ namespace core
         void load();
         void unload();
 
+        void reload_settings();
         void remove_torrent(const std::shared_ptr<torrent> &torrent, bool remove_data = false);
 
         void on_torrent_added(const std::function<void(const std::shared_ptr<torrent>&)> &callback);
@@ -44,6 +46,7 @@ namespace core
         typedef std::shared_ptr<torrent> torrent_ptr;
         typedef std::map<libtorrent::sha1_hash, torrent_ptr> torrent_map_t;
 
+        std::shared_ptr<libtorrent::settings_pack> get_session_settings();
         void load_state();
         void load_torrents();
         void read_alerts();

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -186,7 +186,7 @@ void application::on_torrent_context_menu(const POINT &p, const std::vector<std:
 
 void application::on_view_preferences()
 {
-    controllers::view_preferences_controller view_prefs(main_window_);
+    controllers::view_preferences_controller view_prefs(sess_, main_window_);
     view_prefs.execute();
 }
 


### PR DESCRIPTION
This loads all configured session settings (incl. proxy) when loading PicoTorrent as well as when changing the settings from the preferences dialog.