### PR TITLE
Fix a bug in taskbar list on W7

### DIFF
--- a/include/picotorrent/ui/taskbar_list.hpp
+++ b/include/picotorrent/ui/taskbar_list.hpp
@@ -14,6 +14,7 @@ namespace ui
         taskbar_list(HWND hParent);
         ~taskbar_list();
 
+        void set_progress_state(TBPFLAG flags);
         void set_progress_value(uint64_t completed, uint64_t total);
 
     private:

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -17,6 +17,7 @@
 #include <picotorrent/ui/torrent_list_item.hpp>
 #include <picotorrent/ui/torrent_list_view.hpp>
 #include <shellapi.h>
+#include <shobjidl.h>
 #include <strsafe.h>
 
 namespace core = picotorrent::core;
@@ -482,7 +483,17 @@ LRESULT main_window::wnd_proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
             }
         }
 
-        taskbar_->set_progress_value(done, wanted);
+        if (wanted - done > 0)
+        {
+            taskbar_->set_progress_state(TBPF_NORMAL);
+            taskbar_->set_progress_value(done, wanted);
+        }
+        else
+        {
+            taskbar_->set_progress_state(TBPF_NOPROGRESS);
+        }
+
+
         sleep_manager_->refresh(hasActiveDownloads);
 
         break;

--- a/src/ui/taskbar_list.cpp
+++ b/src/ui/taskbar_list.cpp
@@ -18,6 +18,11 @@ taskbar_list::~taskbar_list()
     }
 }
 
+void taskbar_list::set_progress_state(TBPFLAG flags)
+{
+    list_->SetProgressState(hParent_, flags);
+}
+
 void taskbar_list::set_progress_value(uint64_t completed, uint64_t total)
 {
     list_->SetProgressValue(hParent_, completed, total);


### PR DESCRIPTION
When running on W7, the taskbar list would show green even though no torrents were active. This fix disables progress reporting in the taskbar when we have zero wanted bytes.