### PR TITLE
Show correct file structure when adding torrents.

### DIFF
--- a/include/picotorrent/core/torrent_info.hpp
+++ b/include/picotorrent/core/torrent_info.hpp
@@ -33,7 +33,7 @@ namespace core
 
         static torrent_info_ptr try_load(const filesystem::path &p);
 
-        std::string file_name(int index);
+        std::string file_path(int index);
         int64_t file_size(int index);
         std::string name();
         int num_files();

--- a/src/app/controllers/add_torrent_controller.cpp
+++ b/src/app/controllers/add_torrent_controller.cpp
@@ -246,7 +246,7 @@ void add_torrent_controller::show_torrent(int index)
             StrFormatByteSize64((UINT)req->torrent_info()->file_size(i), &file_size[0], (UINT)file_size.size());
 
             dlg_->add_torrent_file(
-                to_wstring(req->torrent_info()->file_name(i)),
+                to_wstring(req->torrent_info()->file_path(i)),
                 file_size,
                 get_prio_str(req->file_priority(i)));
         }

--- a/src/core/torrent_info.cpp
+++ b/src/core/torrent_info.cpp
@@ -49,9 +49,9 @@ std::shared_ptr<torrent_info> torrent_info::try_load(const fs::path &path)
     return std::make_shared<torrent_info>(buf);
 }
 
-std::string torrent_info::file_name(int index)
+std::string torrent_info::file_path(int index)
 {
-    return info_->files().file_name(index);
+    return info_->files().file_path(index);
 }
 
 int64_t torrent_info::file_size(int index)


### PR DESCRIPTION
Fixes an oversight when adding multi-file torrents, where the add torrent dialog did not show the file path inside the torrent but just the file name.

Closes #96 