### PR TITLE
Fix the Chocolatey package validator warnings.

### DIFF
--- a/chocolatey/picotorrent.nuspec
+++ b/chocolatey/picotorrent.nuspec
@@ -16,7 +16,7 @@
     <!--<docsUrl></docsUrl>
     <mailingListUrl></mailingListUrl>-->
     <bugTrackerUrl>https://github.com/picotorrent/picotorrent/issues</bugTrackerUrl>
-    <tags>picotorrent bittorrent</tags>
+    <tags>picotorrent bittorrent admin</tags>
     <copyright>Copyright 2015, PicoTorrent contributors.</copyright>
     <licenseUrl>https://raw.githubusercontent.com/picotorrent/picotorrent/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/chocolatey/picotorrent.nuspec
+++ b/chocolatey/picotorrent.nuspec
@@ -25,7 +25,7 @@
       <dependency id="" version="__VERSION__" />
       <dependency id="" />
     </dependencies>-->
-    <releaseNotes></releaseNotes>
+    <releaseNotes>https://github.com/picotorrent/picotorrent/releases/tag/v$version$</releaseNotes>
     <!--<provides></provides>-->
   </metadata>
   <files>

--- a/chocolatey/tools/chocolateyuninstall.ps1
+++ b/chocolatey/tools/chocolateyuninstall.ps1
@@ -1,6 +1,26 @@
-$app = Get-WmiObject -Class Win32_Product | Where-Object {$_.Name -eq 'PicoTorrent'}
-  
-if ($app) {
-    $msiArgs = $('/x' + $app.IdentifyingNumber + ' /q REBOOT=ReallySuppress')
-    Start-ChocolateyProcessAsAdmin $msiArgs 'msiexec'
+$ErrorActionPreference = 'Stop'
+
+$local_key       = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
+$machine_key     = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+$machine_key6432 = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+
+$key = Get-ItemProperty -Path @($machine_key6432, $machine_key, $local_key) `
+                        -ErrorAction SilentlyContinue `
+                        | ? { $_.DisplayName -like "PicoTorrent*" }
+
+if ($key.Count -eq 1) {
+  $key | % {
+    Uninstall-ChocolateyPackage -PackageName "picotorrent" `
+                                -FileType "EXE" `
+                                -SilentArgs "/quiet" `
+                                -ValidExitCodes @(0) `
+                                -File $_.UninstallString
+  }
+} elseif ($key.Count -eq 0) {
+  Write-Warning "PicoTorrent has already been uninstalled by other means."
+} elseif ($key.Count -gt 1) {
+  Write-Warning "$key.Count matches found!"
+  Write-Warning "To prevent accidental data loss, no programs will be uninstalled."
+  Write-Warning "Please alert package maintainer the following keys were matched:"
+  $key | % {Write-Warning "- $_.DisplayName"}
 }


### PR DESCRIPTION
Small fixes to the `nuspec` and `chocolateyuninstall.ps1` fixing warnings the friendly package validator gave us.