### PR TITLE
(GH-106) Fix torrent file limit.

### DIFF
--- a/src/app/controllers/add_torrent_controller.cpp
+++ b/src/app/controllers/add_torrent_controller.cpp
@@ -231,23 +231,24 @@ void add_torrent_controller::on_torrent_files_context_menu(const std::vector<int
 void add_torrent_controller::show_torrent(int index)
 {
     std::shared_ptr<core::add_request> &req = requests_[index];
+    core::torrent_info_ptr ti = req->torrent_info();
 
-    if (req->torrent_info())
+    if (ti)
     {
         std::wstring friendly_size(L"\0", 64);
-        StrFormatByteSize64((UINT)req->torrent_info()->total_size(), &friendly_size[0], (UINT)friendly_size.size());
+        StrFormatByteSize64((UINT)ti->total_size(), &friendly_size[0], (UINT)friendly_size.size());
         dlg_->set_size(friendly_size);
 
         dlg_->clear_torrent_files();
         dlg_->enable_files();
 
-        for (int i = 0; i < req->torrent_info()->num_files(); i++)
+        for (int i = 0; i < ti->num_files(); i++)
         {
             std::wstring file_size(L"\0", 64);
-            StrFormatByteSize64((UINT)req->torrent_info()->file_size(i), &file_size[0], (UINT)file_size.size());
+            StrFormatByteSize64((UINT)ti->file_size(i), &file_size[0], (UINT)file_size.size());
 
             dlg_->add_torrent_file(
-                to_wstring(req->torrent_info()->file_path(i)),
+                to_wstring(ti->file_path(i)),
                 file_size,
                 get_prio_str(req->file_priority(i)));
         }

--- a/src/core/add_request.cpp
+++ b/src/core/add_request.cpp
@@ -28,7 +28,7 @@ add_request::~add_request()
 
 int add_request::file_priority(int file_index)
 {
-    if (params_->file_priorities.size() < (uint8_t)(file_index + 1))
+    if (params_->file_priorities.size() < (file_index + 1))
     {
         return 4; // Normal priority according to libtorrent
     }
@@ -63,7 +63,7 @@ std::wstring add_request::url()
 
 void add_request::set_file_priority(int file_index, int priority)
 {
-    if (params_->file_priorities.size() < (uint8_t)(file_index + 1))
+    if (params_->file_priorities.size() < (file_index + 1))
     {
         params_->file_priorities.resize(file_index + 1);
     }

--- a/src/core/add_request.cpp
+++ b/src/core/add_request.cpp
@@ -28,7 +28,7 @@ add_request::~add_request()
 
 int add_request::file_priority(int file_index)
 {
-    if (params_->file_priorities.size() < (file_index + 1))
+    if (params_->file_priorities.size() < (size_t)(file_index + 1))
     {
         return 4; // Normal priority according to libtorrent
     }
@@ -63,7 +63,7 @@ std::wstring add_request::url()
 
 void add_request::set_file_priority(int file_index, int priority)
 {
-    if (params_->file_priorities.size() < (file_index + 1))
+    if (params_->file_priorities.size() < (size_t)(file_index + 1))
     {
         params_->file_priorities.resize(file_index + 1);
     }


### PR DESCRIPTION
This fixes a bug in the `add_request` class that made a cast from `int` to `uint8_t` due to a misunderstanding of the libtorrent API. This cast created a limit on the files in a torrent to 255. I removed the cast to fix the issue.

Since I was in the same area of code, I tried to add a torrent with many files (>10k) and had a problem with a loop in `add_torrent_controller` that called `add_request.torrent_info` four times for each `add_request`, yielding a huge number of objects being created and destructed, slowing everything down to a halt. I put the `torrent_info` in a local variable to fix the issue.

Closes #106 