### PR TITLE
Remove worker thread from session.

### DIFF
--- a/include/picotorrent/app/application.hpp
+++ b/include/picotorrent/app/application.hpp
@@ -49,10 +49,6 @@ namespace app
         void on_view_preferences();
 
         void on_unhandled_exception(const std::string& stacktrace);
-        void torrent_added(const std::shared_ptr<core::torrent> &torrent);
-        void torrent_finished(const std::shared_ptr<core::torrent> &torrent);
-        void torrent_removed(const std::shared_ptr<core::torrent> &torrent);
-        void torrent_updated(const std::shared_ptr<core::torrent> &torrent);
 
         HANDLE mtx_;
         HACCEL accelerators_;

--- a/include/picotorrent/app/application.hpp
+++ b/include/picotorrent/app/application.hpp
@@ -43,6 +43,7 @@ namespace app
         void on_notifyicon_context_menu(const POINT &p);
         void on_remove_torrents_accelerator(bool remove_data);
         void on_select_all_accelerator();
+        void on_session_alert_notify();
         void on_torrent_activated(const std::shared_ptr<core::torrent> &torrent);
         void on_torrent_context_menu(const POINT &p, const std::vector<std::shared_ptr<core::torrent>> &torrents);
         void on_view_preferences();

--- a/include/picotorrent/ui/main_window.hpp
+++ b/include/picotorrent/ui/main_window.hpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include <windows.h>
 
+#include <picotorrent/common/signals/signal.hpp>
+
 #define WM_TORRENT_ADDED WM_USER+1
 #define WM_TORRENT_REMOVED WM_USER+2
 #define WM_TORRENT_UPDATED WM_USER+3
@@ -43,6 +45,7 @@ namespace ui
         void on_command(int id, const command_func_t &callback);
         void on_copydata(const std::function<void(const std::wstring&)> &callback);
         void on_notifyicon_context_menu(const std::function<void(const POINT &p)> &callback);
+        common::signals::signal_connector<void, void>& on_session_alert_notify();
         void on_torrent_activated(const std::function<void(const std::shared_ptr<core::torrent>&)> &callback);
         void on_torrent_context_menu(const std::function<void(const POINT &p, const std::vector<std::shared_ptr<core::torrent>>&)> &callback);
         void post_message(UINT uMsg, WPARAM wParam, LPARAM lParam);
@@ -69,6 +72,8 @@ namespace ui
         std::shared_ptr<taskbar_list> taskbar_;
         std::wstring last_finished_save_path_;
         std::unique_ptr<sleep_manager> sleep_manager_;
+
+        common::signals::signal<void, void> on_session_alert_notify_;
     };
 }
 }

--- a/include/picotorrent/ui/main_window.hpp
+++ b/include/picotorrent/ui/main_window.hpp
@@ -36,6 +36,11 @@ namespace ui
         main_window();
         ~main_window();
 
+        void torrent_added(const std::shared_ptr<core::torrent>&);
+        void torrent_finished(const std::shared_ptr<core::torrent>&);
+        void torrent_removed(const std::shared_ptr<core::torrent>&);
+        void torrent_updated(const std::shared_ptr<core::torrent>&);
+
         void create();
         void exit();
         std::vector<std::shared_ptr<core::torrent>> get_selected_torrents();

--- a/include/picotorrent/ui/property_sheets/details/peers_page.hpp
+++ b/include/picotorrent/ui/property_sheets/details/peers_page.hpp
@@ -2,7 +2,6 @@
 
 #include <picotorrent/ui/property_sheets/property_sheet_page.hpp>
 #include <map>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -38,11 +37,9 @@ namespace details
         void on_init_dialog();
 
     private:
-        struct peer_state;
-
         std::wstring on_list_display(const std::pair<int, int> &p);
 
-        std::mutex update_mtx_;
+        struct peer_state;
         std::unique_ptr<controls::list_view> list_;
         std::vector<peer_state> peers_;
 

--- a/include/picotorrent/ui/property_sheets/details/trackers_page.hpp
+++ b/include/picotorrent/ui/property_sheets/details/trackers_page.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <picotorrent/ui/property_sheets/property_sheet_page.hpp>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -33,11 +32,9 @@ namespace details
         void on_init_dialog();
 
     private:
-        struct tracker_state;
-
         std::wstring on_list_display(const std::pair<int, int> &p);
 
-        std::mutex update_mtx_;
+        struct tracker_state;
         std::unique_ptr<controls::list_view> list_;
         std::vector<tracker_state> trackers_;
 

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -52,10 +52,10 @@ application::application()
     main_window_->on_torrent_activated(std::bind(&application::on_torrent_activated, this, std::placeholders::_1));
     main_window_->on_torrent_context_menu(std::bind(&application::on_torrent_context_menu, this, std::placeholders::_1, std::placeholders::_2));
 
-    sess_->on_torrent_added().connect(std::bind(&application::torrent_added, this, std::placeholders::_1));
-    sess_->on_torrent_finished().connect(std::bind(&application::torrent_finished, this, std::placeholders::_1));
-    sess_->on_torrent_removed().connect(std::bind(&application::torrent_removed, this, std::placeholders::_1));
-    sess_->on_torrent_updated().connect(std::bind(&application::torrent_updated, this, std::placeholders::_1));
+    sess_->on_torrent_added().connect(std::bind(&ui::main_window::torrent_added, main_window_, std::placeholders::_1));
+    sess_->on_torrent_finished().connect(std::bind(&ui::main_window::torrent_finished, main_window_, std::placeholders::_1));
+    sess_->on_torrent_removed().connect(std::bind(&ui::main_window::torrent_removed, main_window_, std::placeholders::_1));
+    sess_->on_torrent_updated().connect(std::bind(&ui::main_window::torrent_updated, main_window_, std::placeholders::_1));
 }
 
 application::~application()
@@ -208,24 +208,4 @@ void application::on_unhandled_exception(const std::string &stacktrace)
 {
     controllers::unhandled_exception_controller exception_controller(main_window_, stacktrace);
     exception_controller.execute();
-}
-
-void application::torrent_added(const std::shared_ptr<core::torrent> &torrent)
-{
-    main_window_->post_message(WM_TORRENT_ADDED, NULL, (LPARAM)&torrent);
-}
-
-void application::torrent_finished(const std::shared_ptr<core::torrent> &torrent)
-{
-    main_window_->post_message(WM_TORRENT_FINISHED, NULL, (LPARAM)&torrent);
-}
-
-void application::torrent_removed(const std::shared_ptr<core::torrent> &torrent)
-{
-    main_window_->send_message(WM_TORRENT_REMOVED, NULL, (LPARAM)&torrent);
-}
-
-void application::torrent_updated(const std::shared_ptr<core::torrent> &torrent)
-{
-    main_window_->post_message(WM_TORRENT_UPDATED, NULL, (LPARAM)&torrent);
 }

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -48,13 +48,14 @@ application::application()
     main_window_->on_close(std::bind(&application::on_close, this));
     main_window_->on_copydata(std::bind(&application::on_command_line_args, this, std::placeholders::_1));
     main_window_->on_notifyicon_context_menu(std::bind(&application::on_notifyicon_context_menu, this, std::placeholders::_1));
+    main_window_->on_session_alert_notify().connect(std::bind(&application::on_session_alert_notify, this));
     main_window_->on_torrent_activated(std::bind(&application::on_torrent_activated, this, std::placeholders::_1));
     main_window_->on_torrent_context_menu(std::bind(&application::on_torrent_context_menu, this, std::placeholders::_1, std::placeholders::_2));
 
-    sess_->on_torrent_added(std::bind(&application::torrent_added, this, std::placeholders::_1));
-    sess_->on_torrent_finished(std::bind(&application::torrent_finished, this, std::placeholders::_1));
-    sess_->on_torrent_removed(std::bind(&application::torrent_removed, this, std::placeholders::_1));
-    sess_->on_torrent_updated(std::bind(&application::torrent_updated, this, std::placeholders::_1));
+    sess_->on_torrent_added().connect(std::bind(&application::torrent_added, this, std::placeholders::_1));
+    sess_->on_torrent_finished().connect(std::bind(&application::torrent_finished, this, std::placeholders::_1));
+    sess_->on_torrent_removed().connect(std::bind(&application::torrent_removed, this, std::placeholders::_1));
+    sess_->on_torrent_updated().connect(std::bind(&application::torrent_updated, this, std::placeholders::_1));
 }
 
 application::~application()
@@ -119,7 +120,7 @@ bool application::is_single_instance()
 int application::run(const std::wstring &args)
 {
     main_window_->create();
-    sess_->load();
+    sess_->load(main_window_->handle());
 
     if (!args.empty())
     {
@@ -168,6 +169,11 @@ void application::on_notifyicon_context_menu(const POINT &p)
 void application::on_select_all_accelerator()
 {
     main_window_->select_all_torrents();
+}
+
+void application::on_session_alert_notify()
+{
+    sess_->notify();
 }
 
 void application::on_remove_torrents_accelerator(bool remove_data)

--- a/src/app/controllers/add_torrent_controller.cpp
+++ b/src/app/controllers/add_torrent_controller.cpp
@@ -231,23 +231,24 @@ void add_torrent_controller::on_torrent_files_context_menu(const std::vector<int
 void add_torrent_controller::show_torrent(int index)
 {
     std::shared_ptr<core::add_request> &req = requests_[index];
+    core::torrent_info_ptr ti = req->torrent_info();
 
-    if (req->torrent_info())
+    if (ti)
     {
         std::wstring friendly_size(L"\0", 64);
-        StrFormatByteSize64((UINT)req->torrent_info()->total_size(), &friendly_size[0], (UINT)friendly_size.size());
+        StrFormatByteSize64((UINT)ti->total_size(), &friendly_size[0], (UINT)friendly_size.size());
         dlg_->set_size(friendly_size);
 
         dlg_->clear_torrent_files();
         dlg_->enable_files();
 
-        for (int i = 0; i < req->torrent_info()->num_files(); i++)
+        for (int i = 0; i < ti->num_files(); i++)
         {
             std::wstring file_size(L"\0", 64);
-            StrFormatByteSize64((UINT)req->torrent_info()->file_size(i), &file_size[0], (UINT)file_size.size());
+            StrFormatByteSize64((UINT)ti->file_size(i), &file_size[0], (UINT)file_size.size());
 
             dlg_->add_torrent_file(
-                to_wstring(req->torrent_info()->file_path(i)),
+                to_wstring(ti->file_path(i)),
                 file_size,
                 get_prio_str(req->file_priority(i)));
         }

--- a/src/core/add_request.cpp
+++ b/src/core/add_request.cpp
@@ -28,7 +28,7 @@ add_request::~add_request()
 
 int add_request::file_priority(int file_index)
 {
-    if (params_->file_priorities.size() < (uint8_t)(file_index + 1))
+    if (params_->file_priorities.size() < (size_t)(file_index + 1))
     {
         return 4; // Normal priority according to libtorrent
     }
@@ -63,7 +63,7 @@ std::wstring add_request::url()
 
 void add_request::set_file_priority(int file_index, int priority)
 {
-    if (params_->file_priorities.size() < (uint8_t)(file_index + 1))
+    if (params_->file_priorities.size() < (size_t)(file_index + 1))
     {
         params_->file_priorities.resize(file_index + 1);
     }

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -20,8 +20,12 @@
 #include <shobjidl.h>
 #include <strsafe.h>
 
+#define PT_SESSION_NOTIFY WM_USER+1337
+
 namespace core = picotorrent::core;
 namespace fs = picotorrent::filesystem;
+using picotorrent::common::signals::signal;
+using picotorrent::common::signals::signal_connector;
 using picotorrent::common::to_wstring;
 using picotorrent::ui::dialogs::about_dialog;
 using picotorrent::ui::main_window;
@@ -118,6 +122,11 @@ void main_window::on_notifyicon_context_menu(const std::function<void(const POIN
     notifyicon_context_cb_ = callback;
 }
 
+signal_connector<void, void>& main_window::on_session_alert_notify()
+{
+    return on_session_alert_notify_;
+}
+
 void main_window::on_torrent_activated(const std::function<void(const std::shared_ptr<core::torrent>&)> &callback)
 {
     torrent_activated_cb = callback;
@@ -159,6 +168,12 @@ LRESULT main_window::wnd_proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 
     switch (uMsg)
     {
+    case PT_SESSION_NOTIFY:
+    {
+        on_session_alert_notify_.emit();
+        break;
+    }
+
     case WM_TORRENT_ADDED:
     {
         const core::torrent_ptr &t = *(core::torrent_ptr*)lParam;

--- a/src/ui/property_sheets/details/peers_page.cpp
+++ b/src/ui/property_sheets/details/peers_page.cpp
@@ -43,13 +43,10 @@ peers_page::peers_page()
 
 peers_page::~peers_page()
 {
-    std::unique_lock<std::mutex> lock(update_mtx_);
 }
 
 void peers_page::refresh(const std::vector<peer> &peers)
 {
-    std::unique_lock<std::mutex> lock(update_mtx_);
-
     for (peer_state &ps : peers_)
     {
         ps.dirty = false;
@@ -104,8 +101,6 @@ void peers_page::on_init_dialog()
 
 std::wstring peers_page::on_list_display(const std::pair<int, int> &p)
 {
-    std::unique_lock<std::mutex> lock(update_mtx_);
-
     peer_state &ps = peers_[p.second];
 
     switch (p.first)

--- a/src/ui/property_sheets/details/trackers_page.cpp
+++ b/src/ui/property_sheets/details/trackers_page.cpp
@@ -41,13 +41,10 @@ trackers_page::trackers_page()
 
 trackers_page::~trackers_page()
 {
-    std::unique_lock<std::mutex>(update_mtx_);
 }
 
 void trackers_page::refresh(const std::vector<tracker> &trackers)
 {
-    std::unique_lock<std::mutex>(update_mtx_);
-
     for (tracker_state &ts : trackers_)
     {
         ts.dirty = false;
@@ -95,8 +92,6 @@ void trackers_page::on_init_dialog()
 
 std::wstring trackers_page::on_list_display(const std::pair<int, int> &p)
 {
-    std::unique_lock<std::mutex> lock(update_mtx_);
-
     const tracker_state &t = trackers_[p.second];
 
     switch (p.first)


### PR DESCRIPTION
This will remove the worker thread from the `session` class which was responsible for running in the background and reading alerts from the libtorrent session. Instead we use `libtorrent::session::set_alert_notify` to post a message to our main window which then triggers an alert read.

Removing the worker thread will keep the UI on a single thread, which makes UI updates more safe.