### PR TITLE
Fix context menu

### DIFF
--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -456,6 +456,13 @@ LRESULT main_window::wnd_proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
         {
             if (nmhdr->hwndFrom == list_view_->handle())
             {
+                std::vector<int> selectedItems = list_view_->get_selected_items();
+
+                if (selectedItems.size() == 0)
+                {
+                    break;
+                }
+
                 if (torrent_context_cb_)
                 {
                     POINT pt;


### PR DESCRIPTION
Prevent context menu from showing up with no torrents selected, which also prevents a crash if you selected 'Open in explorer' with no torrent(s) selected.

Not sure if it's your ideal fix, but it's the same code that got removed from a previous commit.