### PR TITLE
Add menu item to check for update.

### DIFF
--- a/include/picotorrent/app/application.hpp
+++ b/include/picotorrent/app/application.hpp
@@ -37,6 +37,7 @@ namespace app
         int run(const std::wstring &args);
 
     private:
+        void on_check_for_update();
         bool on_close();
         void on_command_line_args(const std::wstring &args);
         void on_file_add_torrent();

--- a/include/picotorrent/app/controllers/application_update_controller.hpp
+++ b/include/picotorrent/app/controllers/application_update_controller.hpp
@@ -26,11 +26,11 @@ namespace controllers
         application_update_controller(const std::shared_ptr<ui::main_window> &wnd);
         ~application_update_controller();
 
-        void execute();
+        void execute(bool forced = false);
 
     protected:
         void notify(const std::wstring &title, const net::uri &uri, const std::wstring &version);
-        void on_response(const net::http_response &response);
+        void on_response(const net::http_response &response, bool forced);
 
     private:
         std::shared_ptr<net::http_client> http_;

--- a/include/picotorrent/ui/resources.hpp
+++ b/include/picotorrent/ui/resources.hpp
@@ -35,6 +35,7 @@
 #define ID_FILE_EXIT 9002
 #define ID_VIEW_PREFERENCES 9101
 #define ID_HELP_ABOUT 9201
+#define ID_HELP_CHECK_FOR_UPDATE 9203
 
 // Preferences dialog
 #define ID_PREFS_DEFSAVEPATH 9101

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -44,6 +44,7 @@ application::application()
     main_window_->on_command(IDA_REMOVE_TORRENTS_DATA, std::bind(&application::on_remove_torrents_accelerator, this, true));
     main_window_->on_command(IDA_SELECT_ALL, std::bind(&application::on_select_all_accelerator, this));
     main_window_->on_command(ID_VIEW_PREFERENCES, std::bind(&application::on_view_preferences, this));
+    main_window_->on_command(ID_HELP_CHECK_FOR_UPDATE, std::bind(&application::on_check_for_update, this));
 
     main_window_->on_close(std::bind(&application::on_close, this));
     main_window_->on_copydata(std::bind(&application::on_command_line_args, this, std::placeholders::_1));
@@ -138,6 +139,11 @@ int application::run(const std::wstring &args)
 
     sess_->unload();
     return result;
+}
+
+void application::on_check_for_update()
+{
+    updater_->execute(true);
 }
 
 bool application::on_close()

--- a/src/resources/pico.rc
+++ b/src/resources/pico.rc
@@ -42,6 +42,8 @@ IDR_MAINMENU MENU
     POPUP "&Help"
     {
         MENUITEM "&About", ID_HELP_ABOUT
+        MENUITEM SEPARATOR
+        MENUITEM "&Check for update", ID_HELP_CHECK_FOR_UPDATE
     }
 }
 


### PR DESCRIPTION
This adds a menu item under `Help -> Check for update` that forces a check for update. It overrides the option to ignore an update and always prompts if one is or isn't available.

Closes #111