### PR TITLE
(GH-112) Show more tracker status in details view.

### DIFF
--- a/include/picotorrent/core/torrent.hpp
+++ b/include/picotorrent/core/torrent.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -12,7 +13,9 @@
 namespace libtorrent
 {
     struct peer_info;
+    struct scrape_reply_alert;
     struct torrent_status;
+    struct tracker_reply_alert;
 }
 
 namespace picotorrent
@@ -25,6 +28,7 @@ namespace core
     class torrent;
     class torrent_info;
     class tracker;
+    class tracker_status;
 
     typedef std::shared_ptr<torrent> torrent_ptr;
 
@@ -56,6 +60,7 @@ namespace core
         void file_progress(std::vector<int64_t> &progress, int flags = 0) const;
         std::vector<peer> get_peers();
         std::vector<tracker> get_trackers();
+        tracker_status& get_tracker_status(const std::string &url);
         bool has_error() const;
         std::shared_ptr<hash> info_hash();
         bool is_checking() const;
@@ -94,9 +99,12 @@ namespace core
         void unregister_updated_callback(const std::function<void()> &callback);
 
     private:
+        void handle(const libtorrent::scrape_reply_alert &alert);
+        void handle(const libtorrent::tracker_reply_alert &alert);
         void update(std::unique_ptr<libtorrent::torrent_status> status);
         void update_state();
 
+        std::map<std::string, tracker_status> tracker_status_;
         std::unique_ptr<libtorrent::torrent_status> status_;
         torrent_state state_;
 

--- a/include/picotorrent/core/tracker.hpp
+++ b/include/picotorrent/core/tracker.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -28,6 +29,7 @@ namespace core
         ~tracker();
 
         std::string message() const;
+        std::chrono::seconds next_announce_in() const;
         int scrape_complete() const;
         status_t status() const;
         std::string url() const;

--- a/include/picotorrent/core/tracker_status.hpp
+++ b/include/picotorrent/core/tracker_status.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+namespace picotorrent
+{
+namespace core
+{
+    class tracker_status
+    {
+    public:
+        tracker_status()
+            : num_peers(-1),
+            scrape_complete(-1),
+            scrape_incomplete(-1)
+        {
+        }
+
+        std::string message;
+        int num_peers;
+        int scrape_complete;
+        int scrape_incomplete;
+    };
+}
+}

--- a/include/picotorrent/ui/property_sheets/details/trackers_page.hpp
+++ b/include/picotorrent/ui/property_sheets/details/trackers_page.hpp
@@ -8,6 +8,7 @@ namespace picotorrent
 {
 namespace core
 {
+    class torrent;
     class tracker;
 }
 namespace ui
@@ -26,7 +27,7 @@ namespace details
         trackers_page();
         ~trackers_page();
 
-        void refresh(const std::vector<core::tracker> &trackers);
+        void refresh(const std::shared_ptr<core::torrent> &torrent);
 
     protected:
         void on_init_dialog();

--- a/src/app/controllers/torrent_details_controller.cpp
+++ b/src/app/controllers/torrent_details_controller.cpp
@@ -195,5 +195,5 @@ void torrent_details_controller::update_peers()
 
 void torrent_details_controller::update_trackers()
 {
-    trackers_->refresh(torrent_->get_trackers());
+    trackers_->refresh(torrent_);
 }

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -439,6 +439,18 @@ void session::notify()
             torrents_.erase(al->info_hash);
             break;
         }
+        case lt::tracker_reply_alert::alert_type:
+        {
+            lt::tracker_reply_alert *al = lt::alert_cast<lt::tracker_reply_alert>(alert);
+            torrent_map_t::iterator &find = torrents_.find(al->handle.info_hash());
+            if (find != torrents_.end()) { find->second->handle(*al); }
+            break;
+        }
+        case lt::scrape_reply_alert::alert_type:
+            lt::scrape_reply_alert *al = lt::alert_cast<lt::scrape_reply_alert>(alert);
+            torrent_ptr &torrent = torrents_.at(al->handle.info_hash());
+            torrent->handle(*al);
+            break;
         }
     }
 }

--- a/src/core/tracker.cpp
+++ b/src/core/tracker.cpp
@@ -24,6 +24,11 @@ std::string tracker::message() const
     return ae_->message;
 }
 
+std::chrono::seconds tracker::next_announce_in() const
+{
+    return std::chrono::seconds(ae_->next_announce_in());
+}
+
 int tracker::scrape_complete() const
 {
     return ae_->scrape_complete;

--- a/src/ui/controls/list_view.cpp
+++ b/src/ui/controls/list_view.cpp
@@ -136,7 +136,7 @@ void list_view::set_image_list(HIMAGELIST img)
 
 void list_view::set_item_count(int count)
 {
-    ListView_SetItemCount(handle(), count);
+    ListView_SetItemCountEx(handle(), count, LVSICF_NOSCROLL);
 }
 
 LRESULT list_view::subclass_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData)

--- a/src/ui/property_sheets/details/trackers_page.cpp
+++ b/src/ui/property_sheets/details/trackers_page.cpp
@@ -137,6 +137,12 @@ std::wstring trackers_page::on_list_display(const std::pair<int, int> &p)
         std::chrono::minutes min_left = std::chrono::duration_cast<std::chrono::minutes>(next);
         std::chrono::seconds sec_left = std::chrono::duration_cast<std::chrono::seconds>(next - min_left);
 
+        // Return unknown if more than 60 minutes
+        if (min_left.count() >= 60)
+        {
+            return L"-";
+        }
+
         TCHAR t[100];
         StringCchPrintf(
             t,

--- a/src/ui/property_sheets/details/trackers_page.cpp
+++ b/src/ui/property_sheets/details/trackers_page.cpp
@@ -1,21 +1,28 @@
 #include <picotorrent/ui/property_sheets/details/trackers_page.hpp>
 
 #include <picotorrent/common/string_operations.hpp>
+#include <picotorrent/core/torrent.hpp>
 #include <picotorrent/core/tracker.hpp>
+#include <picotorrent/core/tracker_status.hpp>
 #include <picotorrent/ui/controls/list_view.hpp>
 #include <picotorrent/ui/resources.hpp>
 #include <picotorrent/ui/scaler.hpp>
 
 #include <cassert>
+#include <chrono>
 #include <shlwapi.h>
 #include <strsafe.h>
 
 #define LIST_COLUMN_URL    1
 #define LIST_COLUMN_STATUS 2
-#define LIST_COLUMN_PEERS  3
+#define LIST_COLUMN_UPDATE 3
+#define LIST_COLUMN_PEERS  4
+#define LIST_COLUMN_SCRAPE 5
 
 using picotorrent::common::to_wstring;
+using picotorrent::core::torrent;
 using picotorrent::core::tracker;
+using picotorrent::core::tracker_status;
 using picotorrent::ui::controls::list_view;
 using picotorrent::ui::property_sheets::details::trackers_page;
 using picotorrent::ui::scaler;
@@ -28,6 +35,7 @@ struct trackers_page::tracker_state
     }
 
     tracker tracker;
+    tracker_status status;
     bool dirty;
 };
 
@@ -43,20 +51,23 @@ trackers_page::~trackers_page()
 {
 }
 
-void trackers_page::refresh(const std::vector<tracker> &trackers)
+void trackers_page::refresh(const std::shared_ptr<torrent> &torrent)
 {
     for (tracker_state &ts : trackers_)
     {
         ts.dirty = false;
     }
 
-    for (const tracker &t : trackers)
+    for (const tracker &t : torrent->get_trackers())
     {
+        tracker_status &ts = torrent->get_tracker_status(t.url());
+
         // TODO: std::find_if uses moderate CPU here, and in a loop as well. maybe a std::map is better for peers_.
         auto &item = std::find_if(trackers_.begin(), trackers_.end(), [t](const tracker_state &ts) { return t.url() == ts.tracker.url(); });
 
         if (item != trackers_.end())
         {
+            item->status = ts;
             item->tracker = t;
             item->dirty = true;
         }
@@ -64,6 +75,7 @@ void trackers_page::refresh(const std::vector<tracker> &trackers)
         {
             tracker_state state(t);
             state.dirty = true;
+            state.status = ts;
             trackers_.push_back(state);
         }
     }
@@ -74,7 +86,6 @@ void trackers_page::refresh(const std::vector<tracker> &trackers)
         return !t.dirty;
     }), trackers_.end());
 
-    assert(trackers_.size() == trackers.size());
     list_->set_item_count((int)trackers_.size());
 }
 
@@ -83,9 +94,11 @@ void trackers_page::on_init_dialog()
     HWND hList = GetDlgItem(handle(), ID_DETAILS_TRACKERS_LIST);
     list_ = std::make_unique<list_view>(hList);
 
-    list_->add_column(LIST_COLUMN_URL,    L"Url",    scaler::x(240));
-    list_->add_column(LIST_COLUMN_STATUS, L"Status", scaler::x(120));
-    //list_->add_column(LIST_COLUMN_PEERS,  L"Peers",  scaler::x(80), list_view::number);
+    list_->add_column(LIST_COLUMN_URL,    L"Url",           scaler::x(240));
+    list_->add_column(LIST_COLUMN_STATUS, L"Status",        scaler::x(100));
+    list_->add_column(LIST_COLUMN_UPDATE, L"Next announce", scaler::x(100), list_view::number);
+    list_->add_column(LIST_COLUMN_PEERS,  L"Peers",         scaler::x(80),  list_view::number);
+    list_->add_column(LIST_COLUMN_SCRAPE, L"Scrape",        scaler::x(80),  list_view::number);
 
     list_->on_display().connect(std::bind(&trackers_page::on_list_display, this, std::placeholders::_1));
 }
@@ -112,6 +125,48 @@ std::wstring trackers_page::on_list_display(const std::pair<int, int> &p)
             return L"Unknown";
         }
         break;
+    case LIST_COLUMN_UPDATE:
+    {
+        std::chrono::seconds next = t.tracker.next_announce_in();
+
+        if (next.count() < 0)
+        {
+            return L"-";
+        }
+
+        std::chrono::minutes min_left = std::chrono::duration_cast<std::chrono::minutes>(next);
+        std::chrono::seconds sec_left = std::chrono::duration_cast<std::chrono::seconds>(next - min_left);
+
+        TCHAR t[100];
+        StringCchPrintf(
+            t,
+            ARRAYSIZE(t),
+            L"%dm %ds",
+            min_left.count(),
+            sec_left.count());
+        return t;
+    }
+    case LIST_COLUMN_PEERS:
+        if (t.status.num_peers < 0)
+        {
+            return L"-";
+        }
+
+        return std::to_wstring(t.status.num_peers);
+    case LIST_COLUMN_SCRAPE:
+    {
+        int complete = t.status.scrape_complete;
+        int incomplete = t.status.scrape_incomplete;
+
+        TCHAR t[100];
+        StringCchPrintf(
+            t,
+            ARRAYSIZE(t),
+            L"%s/%s",
+            complete < 0 ? L"-" : std::to_wstring(complete).c_str(),
+            incomplete < 0 ? L"-" : std::to_wstring(incomplete).c_str());
+        return t;
+    }
     default:
         return L"<unknown column>";
     }


### PR DESCRIPTION
In response to #112, this shows time until next announce, peer count and scrape status in the tracker details view.

![image](https://cloud.githubusercontent.com/assets/1491824/12827323/8a08b71a-cb7f-11e5-9842-3303c92cbb5a.png)

Closes #112 