### PR TITLE
(GH-120) Fix torrent file priority

### DIFF
--- a/src/core/add_request.cpp
+++ b/src/core/add_request.cpp
@@ -16,6 +16,8 @@ using namespace picotorrent::common;
 using picotorrent::core::add_request;
 using picotorrent::core::torrent_info;
 
+#define FILE_PRIO_NORMAL 4
+
 add_request::add_request()
     : params_(std::make_unique<lt::add_torrent_params>())
 {   
@@ -30,7 +32,7 @@ int add_request::file_priority(int file_index)
 {
     if (params_->file_priorities.size() < (size_t)(file_index + 1))
     {
-        return 4; // Normal priority according to libtorrent
+        return FILE_PRIO_NORMAL; // Normal priority according to libtorrent
     }
 
     return params_->file_priorities[file_index];
@@ -65,7 +67,7 @@ void add_request::set_file_priority(int file_index, int priority)
 {
     if (params_->file_priorities.size() < (size_t)(file_index + 1))
     {
-        params_->file_priorities.resize(file_index + 1);
+        params_->file_priorities.resize(file_index + 1, FILE_PRIO_NORMAL);
     }
 
     params_->file_priorities[file_index] = priority;

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -419,13 +419,13 @@ void session::notify()
         case lt::torrent_finished_alert::alert_type:
         {
             lt::torrent_finished_alert *al = lt::alert_cast<lt::torrent_finished_alert>(alert);
-            torrent_ptr &torrent = torrents_.at(al->handle.info_hash());
+            torrent_map_t::iterator &find = torrents_.find(al->handle.info_hash());
 
             // Check `total_download` to see if we have a real finished torrent or one that
             // was finished when we added it and just completed the hash check.
-            if (al->handle.status().total_download > 0)
+            if (find != torrents_.end() && al->handle.status().total_download > 0)
             {
-                on_torrent_finished_.emit(torrent);
+                on_torrent_finished_.emit(find->second);
             }
             break;
         }


### PR DESCRIPTION
This fixes the issue with with files getting the wrong priority when setting the last file's priotity. Also it tries to remedy the fact that libtorrent emits the `torrent_finished_alert` before the `add_torrent_alert` which caused a crash.

Closes #120 