### PR TITLE
Update build scripts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -29,7 +29,7 @@ if($WhatIf.IsPresent) {
 
 # Try download NuGet.exe if do not exist.
 if (!(Test-Path $NUGET_EXE)) {
-    Invoke-WebRequest -Uri http://nuget.org/nuget.exe -OutFile $NUGET_EXE
+    Invoke-WebRequest -Uri https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe -OutFile $NUGET_EXE
 }
 
 # Make sure NuGet exists where we expect it.

--- a/installer/PicoTorrent.wxs
+++ b/installer/PicoTorrent.wxs
@@ -33,8 +33,8 @@
                     <Directory Id="LANGDIR" Name="lang" />
 
                     <Component Id="C_PicoTorrent" Guid="5eb6d6ac-dc76-4fac-80ff-f31a4c05f205">
-                        <File Id="F_PicoTorrent.exe" Name="PicoTorrent.exe" Source="$(var.BuildDirectory)\PicoTorrent.exe" KeyPath="yes" />
-                        <File Id="F_PicoTorrentCore.dll" Name="PicoTorrentCore.dll" Source="$(var.BuildDirectory)\PicoTorrentCore.dll" />
+                        <File Id="F_PicoTorrent.exe" Name="PicoTorrent.exe" Source="$(var.PublishDirectory)\PicoTorrent.exe" KeyPath="yes" />
+                        <File Id="F_PicoTorrentCore.dll" Name="PicoTorrentCore.dll" Source="$(var.PublishDirectory)\PicoTorrentCore.dll" />
 
                         <!-- Shortcut -->
                         <Shortcut Id="S_PicoTorrent"
@@ -171,11 +171,11 @@
                     </Component>
 
                     <Component Id="C_PicoDebug">
-                        <File Id="F_PicoTorrent.pdb" Name="PicoTorrent.pdb" Source="$(var.BuildDirectory)\PicoTorrent.pdb" />
+                        <File Id="F_PicoTorrent.pdb" Name="PicoTorrent.pdb" Source="$(var.PublishDirectory)\PicoTorrent.pdb" />
                     </Component>
 
                     <Component Id="C_PicoCoreDebug">
-                        <File Id="F_PicoTorrentCore.pdb" Name="PicoTorrentCore.pdb" Source="$(var.BuildDirectory)\PicoTorrentCore.pdb" />
+                        <File Id="F_PicoTorrentCore.pdb" Name="PicoTorrentCore.pdb" Source="$(var.PublishDirectory)\PicoTorrentCore.pdb" />
                     </Component>
                 </Directory>
             </Directory>
@@ -185,11 +185,19 @@
 
         <ComponentGroup Id="CG_Languages" Directory="LANGDIR">
           <Component Id="C_Lang_1031">
-            <File Name="1031.json" Source="$(var.BuildDirectory)\lang\1031.json" />
+            <File Name="1031.json" Source="$(var.PublishDirectory)\lang\1031.json" />
+          </Component>
+
+          <Component Id="C_Lang_1049">
+            <File Name="1049.json" Source="$(var.PublishDirectory)\lang\1049.json" />
           </Component>
 
           <Component Id="C_Lang_1053">
-            <File Name="1053.json" Source="$(var.BuildDirectory)\lang\1053.json" />
+            <File Name="1053.json" Source="$(var.PublishDirectory)\lang\1053.json" />
+          </Component>
+
+          <Component Id="C_Lang_1062">
+            <File Name="1062.json" Source="$(var.PublishDirectory)\lang\1062.json" />
           </Component>
         </ComponentGroup>
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.6.0" />
-  <package id="Cake.CMake" version="0.0.1" />
+  <package id="Cake" version="0.8.0" />
+  <package id="Cake.CMake" version="0.0.2" />
   <package id="PicoTorrent.Libs" version="0.4.0" />
   <package id="WiX.Toolset" version="3.9.1208" />
 </packages>


### PR DESCRIPTION
`Updated NuGet to v3.3.0`
- Appears to give a nice speed boost when installing packages, using AppVeyor as a benchmark, there's a ~2 minute reduction in the time it takes to acquire packages, compared to the current version of nuget the build script uses.

`Updated Cake to 0.8.0 and Cake.CMake to 0.0.2`

`Created a 'publish' directory and copied all files to be published to it`
- Converted the Build-Installer task & PicoTorrent.wxs installer script to use the 'publish' directory
- Converted the Build-Portable-Package task to zip the 'publish' directory, to automatically grab any new translation files

`Added newest translation files to PicoTorrent.wxs installer script`
- Not familiar with the WiX toolset, so not sure if it's possible or recommended to add an entire directory at once, instead of individual files