### PR TITLE
Support dynamically loading torrents.

### DIFF
--- a/include/picotorrent/core/session.hpp
+++ b/include/picotorrent/core/session.hpp
@@ -10,8 +10,15 @@
 #include <picotorrent/common.hpp>
 #include <picotorrent/core/signals/signal.hpp>
 
+namespace boost {
+    namespace system {
+        class error_code;
+    }
+}
+
 namespace libtorrent
 {
+    typedef boost::system::error_code error_code;
     class session;
     class sha1_hash;
     struct settings_pack;
@@ -49,6 +56,7 @@ namespace core
 
     protected:
         void on_alert_notify();
+        void on_load_torrent(const libtorrent::sha1_hash &hash, std::vector<char> &buf, libtorrent::error_code &ec);
 
     private:
         typedef std::unique_ptr<libtorrent::session> session_ptr;
@@ -65,6 +73,7 @@ namespace core
         void timer_callback();
 
         std::unique_ptr<timer> timer_;
+        std::map<libtorrent::sha1_hash, std::wstring> hash_to_path_;
         torrent_map_t torrents_;
         session_ptr sess_;
 

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -437,6 +437,12 @@ void session::notify()
             if (al->handle.torrent_file())
             {
                 save_torrent(*al->handle.torrent_file());
+
+                fs::directory torrents = environment::get_data_path().combine(L"Torrents");
+                std::wstring hash = lt::convert_to_wstring(lt::to_hex(al->handle.info_hash().to_string()));
+                fs::path torrent(torrents.path().combine((hash + L".torrent")));
+
+                hash_to_path_.insert({ al->handle.info_hash(), torrent.to_string() });
             }
             break;
         }

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -17,6 +17,7 @@
 #include <libtorrent/alert_types.hpp>
 #include <libtorrent/bencode.hpp>
 #include <libtorrent/create_torrent.hpp>
+#include <libtorrent/error_code.hpp>
 #include <libtorrent/peer_info.hpp>
 #include <libtorrent/session.hpp>
 #include <libtorrent/torrent_info.hpp>
@@ -77,6 +78,13 @@ void session::load(HWND hWnd)
 
     hWnd_ = hWnd;
     sess_->set_alert_notify(std::bind(&session::on_alert_notify, this));
+    sess_->set_load_function(
+        std::bind(
+            &session::on_load_torrent,
+            this,
+            std::placeholders::_1,
+            std::placeholders::_2,
+            std::placeholders::_3));
 
     timer_->start();
 }
@@ -119,6 +127,30 @@ signal_connector<void, const session::torrent_ptr&>& session::on_torrent_updated
 void session::on_alert_notify()
 {
     PostMessage(hWnd_, WM_USER + 1337, NULL, NULL);
+}
+
+void session::on_load_torrent(const lt::sha1_hash &hash, std::vector<char> &buf, lt::error_code &ec)
+{
+    auto it = hash_to_path_.find(hash);
+
+    if (it == hash_to_path_.end())
+    {
+        LOG(error) << "Hash-to-path map did not contain the info hash.";
+        ec.assign(boost::system::errc::no_such_file_or_directory, boost::system::generic_category());
+        return;
+    }
+
+    fs::file torrent(it->second);
+
+    if (!torrent.path().exists())
+    {
+        LOG(error) << "Torrent file did not exist when lazy loading.";
+        ec.assign(boost::system::errc::no_such_file_or_directory, boost::system::generic_category());
+    }
+    else
+    {
+        torrent.read_all(buf);
+    }
 }
 
 std::shared_ptr<lt::settings_pack> session::get_session_settings()
@@ -316,6 +348,9 @@ void session::load_torrents()
             }
 
             params.ti = boost::make_shared<lt::torrent_info>(node);
+
+            // Insert into hash-to-path map
+            hash_to_path_.insert({ params.ti->info_hash(), torrent.path().to_string() });
         }
 
         params.flags |= lt::add_torrent_params::flags_t::flag_use_resume_save_path;


### PR DESCRIPTION
Fixes #148 

A simple PR making use of the `set_load_function` of libtorrent to dynamically load torrents when needed instead of keeping them all in memory.