### PR TITLE
Add required runtime files to portable package.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -96,8 +96,15 @@ Task("Setup-Publish-Directory")
     .IsDependentOn("Build")
     .Does(() =>
 {
+    var redistDir = Directory("C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\redist");
+    var runtimeDir = redistDir + Directory(platform) + Directory("Microsoft.VC140.CRT");
+
     var files = new FilePath[]
     {
+        // runtime
+        runtimeDir + File("msvcp140.dll"),
+        runtimeDir + File("vcruntime140.dll"),
+        // picotorrent
         BuildDirectory + File("PicoTorrent.exe"),
         BuildDirectory + File("PicoTorrentCore.dll"),
         BuildDirectory + File("PicoTorrent.pdb"),


### PR DESCRIPTION
Copies to required runtime DLLs to the publish directory to be zipped up for the portable packages.

Should be the solution #153 is looking for.