### PR TITLE
Add status bar to PicoTorrent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(PICOTORRENTCORE_SOURCES
     src/core/hash
     src/core/peer
     src/core/session
+    src/core/session_metrics
     src/core/timer
     src/core/torrent
     src/core/torrent_info
@@ -106,6 +107,7 @@ set(PICOTORRENT_SOURCES
     src/client/ui/open_torrent_dialog
     src/client/ui/scaler
     src/client/ui/sleep_manager
+    src/client/ui/status_bar
     src/client/ui/task_dialog
     src/client/ui/taskbar_list
     src/client/ui/torrent_context_menu

--- a/include/picotorrent/client/ui/main_window.hpp
+++ b/include/picotorrent/client/ui/main_window.hpp
@@ -12,6 +12,7 @@ namespace picotorrent
 {
 namespace core
 {
+    class session;
     class torrent;
 }
 namespace client
@@ -26,6 +27,7 @@ namespace controls
     class notify_icon;
     class taskbar_list;
     class sleep_manager;
+    class status_bar;
 
     class main_window
     {
@@ -33,7 +35,7 @@ namespace controls
         typedef std::function<void()> command_func_t;
         typedef std::map<int, command_func_t> command_map_t;
 
-        main_window();
+        main_window(const std::shared_ptr<core::session> &sess);
         ~main_window();
 
         void torrent_added(const std::shared_ptr<core::torrent>&);
@@ -79,6 +81,8 @@ namespace controls
         std::vector<std::shared_ptr<core::torrent>> torrents_;
         std::shared_ptr<notify_icon> noticon_;
         std::unique_ptr<controls::list_view> list_view_;
+        std::shared_ptr<core::session> sess_;
+        std::unique_ptr<status_bar> status_;
         std::shared_ptr<taskbar_list> taskbar_;
         std::wstring last_finished_save_path_;
         std::unique_ptr<sleep_manager> sleep_manager_;

--- a/include/picotorrent/client/ui/status_bar.hpp
+++ b/include/picotorrent/client/ui/status_bar.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <windows.h>
+
+namespace picotorrent
+{
+namespace client
+{
+namespace ui
+{
+    class status_bar
+    {
+    public:
+        status_bar(HWND hParent);
+        HWND handle();
+        void set_torrent_count(int count);
+        void set_transfer_rates(int dl, int ul);
+
+    private:
+        std::wstring rate_to_string(int rate);
+        HWND hWnd_;
+    };
+}
+}
+}

--- a/include/picotorrent/core/session.hpp
+++ b/include/picotorrent/core/session.hpp
@@ -30,6 +30,7 @@ namespace picotorrent
 namespace core
 {
     class add_request;
+    class session_metrics;
     class timer;
     class torrent;
     class torrent_info;
@@ -42,6 +43,7 @@ namespace core
 
         DLL_EXPORT void add_torrent(const std::shared_ptr<add_request> &add);
         DLL_EXPORT void get_metadata(const std::string &magnet_link);
+        DLL_EXPORT std::shared_ptr<session_metrics> metrics();
 
         DLL_EXPORT void load(HWND hWnd);
         DLL_EXPORT void unload();
@@ -80,6 +82,7 @@ namespace core
         std::map<libtorrent::sha1_hash, std::shared_ptr<torrent_info>> loading_metadata_;
         torrent_map_t torrents_;
         session_ptr sess_;
+        std::shared_ptr<session_metrics> metrics_;
 
         // Handle to our main window
         HWND hWnd_;

--- a/include/picotorrent/core/session_metrics.hpp
+++ b/include/picotorrent/core/session_metrics.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <picotorrent/common.hpp>
+#include <vector>
+
+namespace libtorrent
+{
+    struct stats_metric;
+}
+
+namespace picotorrent
+{
+namespace core
+{
+    class session;
+
+    class session_metrics
+    {
+        friend class session;
+
+    public:
+        session_metrics(const std::vector<libtorrent::stats_metric> &metrics);
+        ~session_metrics();
+
+        DLL_EXPORT uint64_t dht_nodes();
+
+    protected:
+        void update(uint64_t *values, size_t len);
+
+    private:
+        uint64_t get_metric(const char *name);
+        std::vector<libtorrent::stats_metric> metrics_;
+        std::vector<uint64_t> values_;
+    };
+}
+}

--- a/lang/1033.json
+++ b/lang/1033.json
@@ -144,6 +144,7 @@
         "start_with_windows": "Start PicoTorrent with Windows",
         "start_position": "Start position",
         "hidden": "System tray",
-        "minimized": "Minimized"
+        "minimized": "Minimized",
+        "_torrent_s": "%d torrent(s)"
     }
 }

--- a/src/client/application.cpp
+++ b/src/client/application.cpp
@@ -35,11 +35,12 @@ using picotorrent::core::logging::log;
 
 application::application()
     : mtx_(NULL),
-    main_window_(std::make_shared<ui::main_window>()),
-    sess_(std::make_shared<core::session>()),
     accelerators_(LoadAccelerators(GetModuleHandle(NULL), MAKEINTRESOURCE(IDR_PICO_ACCELERATORS)))
 {
     log::instance().set_unhandled_exception_callback(std::bind(&application::on_unhandled_exception, this, std::placeholders::_1));
+
+    sess_ = std::make_shared<core::session>();
+    main_window_ = std::make_shared<ui::main_window>(sess_);
 
     main_window_->on_command(ID_FILE_ADD_TORRENT, std::bind(&application::on_file_add_torrent, this));
     main_window_->on_command(ID_FILE_ADD_MAGNET_LINK, std::bind(&application::on_file_add_magnet_link, this));

--- a/src/client/ui/status_bar.cpp
+++ b/src/client/ui/status_bar.cpp
@@ -1,0 +1,76 @@
+#include <picotorrent/client/ui/status_bar.hpp>
+
+#include <picotorrent/client/i18n/translator.hpp>
+#include <picotorrent/client/ui/scaler.hpp>
+
+#include <commctrl.h>
+#include <shlwapi.h>
+#include <strsafe.h>
+
+using picotorrent::client::ui::scaler;
+using picotorrent::client::ui::status_bar;
+
+status_bar::status_bar(HWND hParent)
+{
+    hWnd_ = CreateWindowEx(
+        0,
+        STATUSCLASSNAME,
+        NULL,
+        SBARS_SIZEGRIP | WS_CHILD | WS_VISIBLE,
+        0, 0, 0, 0,
+        hParent,
+        NULL,
+        GetModuleHandle(NULL),
+        NULL);
+
+    RECT rc;
+    GetClientRect(hWnd_, &rc);
+
+    int parts[2] = {
+        scaler::x(120),
+        rc.right - rc.left
+    };
+
+    SendMessage(hWnd_, SB_SETPARTS, 2, (LPARAM)&parts);
+}
+
+HWND status_bar::handle()
+{
+    return hWnd_;
+}
+
+void status_bar::set_torrent_count(int count)
+{
+    TCHAR text[128];
+    StringCchPrintf(text, ARRAYSIZE(text), TR("_torrent_s"), count);
+    SendMessage(handle(), SB_SETTEXT, 0, (LPARAM)text);
+}
+
+void status_bar::set_transfer_rates(int dl, int ul)
+{
+    TCHAR rates[128];
+    StringCchPrintf(
+        rates,
+        ARRAYSIZE(rates),
+        L"%s: %s, %s: %s",
+        TR("dl"),
+        rate_to_string(dl).c_str(),
+        TR("ul"),
+        rate_to_string(ul).c_str());
+
+    SendMessage(handle(), SB_SETTEXT, 1, (LPARAM)rates);
+
+}
+
+std::wstring status_bar::rate_to_string(int rate)
+{
+    if (rate < 1024)
+    {
+        return L"-";
+    }
+
+    TCHAR t[128];
+    StrFormatByteSize64(rate, t, ARRAYSIZE(t));
+
+    return std::wstring(t) + L"/s";
+}

--- a/src/core/session_metrics.cpp
+++ b/src/core/session_metrics.cpp
@@ -1,0 +1,32 @@
+#include <picotorrent/core/session_metrics.hpp>
+
+#include <libtorrent/session_stats.hpp>
+
+namespace lt = libtorrent;
+using picotorrent::core::session_metrics;
+
+session_metrics::session_metrics(const std::vector<lt::stats_metric> &metrics)
+    : metrics_(metrics)
+{
+}
+
+session_metrics::~session_metrics()
+{
+}
+
+uint64_t session_metrics::dht_nodes()
+{
+    return get_metric("dht.dht_nodes");
+}
+
+void session_metrics::update(uint64_t *values, size_t size)
+{
+    values_.assign(values, values + size);
+}
+
+uint64_t session_metrics::get_metric(const char *name)
+{
+    if (values_.empty()) { return 0; }
+    int idx = lt::find_metric_idx(name);
+    return values_[idx];
+}


### PR DESCRIPTION
Closes #162 

This adds a basic status bar which shows information about the number of torrents as well as total DL/UL rate.

![image](https://cloud.githubusercontent.com/assets/1491824/13230623/586f3b2c-d9a6-11e5-9378-2aa0f7c45bd3.png)

