### PR TITLE
Fix torrent and file size in the add torrent dialog

### DIFF
--- a/src/client/controllers/add_torrent_controller.cpp
+++ b/src/client/controllers/add_torrent_controller.cpp
@@ -210,7 +210,7 @@ void add_torrent_controller::on_torrent_files_context_menu(const std::vector<int
     if (files.size() == 1)
     {
         int prio = req->file_priority(files[0]);
-        
+
         switch (prio)
         {
         case core::torrent::do_not_download:
@@ -272,7 +272,7 @@ void add_torrent_controller::show_torrent(int index)
     if (ti)
     {
         std::wstring friendly_size(L"\0", 64);
-        StrFormatByteSize64((UINT)ti->total_size(), &friendly_size[0], (UINT)friendly_size.size());
+        StrFormatByteSize64(ti->total_size(), &friendly_size[0], (UINT)friendly_size.size());
         dlg_->set_size(friendly_size);
 
         dlg_->clear_torrent_files();
@@ -281,7 +281,7 @@ void add_torrent_controller::show_torrent(int index)
         for (int i = 0; i < ti->num_files(); i++)
         {
             std::wstring file_size(L"\0", 64);
-            StrFormatByteSize64((UINT)ti->file_size(i), &file_size[0], (UINT)file_size.size());
+            StrFormatByteSize64(ti->file_size(i), &file_size[0], (UINT)file_size.size());
 
             dlg_->add_torrent_file(
                 to_wstring(ti->file_path(i)),


### PR DESCRIPTION
If the torrent's total size or individual file size is greater than 4.3GB, it displays a random incorrect value.

Noticed this last night when adding a torrent that was 25GB and the add torrent dialog said it was 791MB.