### PR TITLE
Add support for drag-and-drop.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ set(PICOTORRENT_SOURCES
     src/client/ui/task_dialog
     src/client/ui/taskbar_list
     src/client/ui/torrent_context_menu
+    src/client/ui/torrent_drop_target
 )
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")

--- a/include/picotorrent/client/application.hpp
+++ b/include/picotorrent/client/application.hpp
@@ -9,6 +9,10 @@ namespace picotorrent
 {
 namespace core
 {
+namespace filesystem
+{
+    class path;
+}
     class session;
     class torrent;
 }
@@ -50,6 +54,7 @@ namespace client
         void on_session_alert_notify();
         void on_torrent_activated(const std::shared_ptr<core::torrent> &torrent);
         void on_torrent_context_menu(const POINT &p, const std::vector<std::shared_ptr<core::torrent>> &torrents);
+        void on_torrents_dropped(const std::vector<core::filesystem::path> &files);
         void on_view_preferences();
 
         void on_unhandled_exception(const std::string& stacktrace);

--- a/include/picotorrent/client/controllers/add_torrent_controller.hpp
+++ b/include/picotorrent/client/controllers/add_torrent_controller.hpp
@@ -38,6 +38,7 @@ namespace controllers
 
         void execute();
         void execute(const command_line &cmd);
+        void execute(const std::vector<core::filesystem::path> &files);
         void execute(const std::vector<std::shared_ptr<core::torrent_info>> &torrents);
 
     protected:

--- a/include/picotorrent/client/ui/main_window.hpp
+++ b/include/picotorrent/client/ui/main_window.hpp
@@ -12,6 +12,10 @@ namespace picotorrent
 {
 namespace core
 {
+namespace filesystem
+{
+    class path;
+}
     class session;
     class torrent;
 }
@@ -28,6 +32,7 @@ namespace controls
     class taskbar_list;
     class sleep_manager;
     class status_bar;
+    class torrent_drop_target;
 
     class main_window
     {
@@ -55,6 +60,7 @@ namespace controls
         core::signals::signal_connector<void, void>& on_session_alert_notify();
         void on_torrent_activated(const std::function<void(const std::shared_ptr<core::torrent>&)> &callback);
         void on_torrent_context_menu(const std::function<void(const POINT &p, const std::vector<std::shared_ptr<core::torrent>>&)> &callback);
+        core::signals::signal_connector<void, const std::vector<core::filesystem::path>&>& on_torrents_dropped();
         void post_message(UINT uMsg, WPARAM wParam, LPARAM lParam);
         void send_message(UINT uMsg, WPARAM wParam, LPARAM lParam);
         void select_all_torrents();
@@ -87,6 +93,7 @@ namespace controls
         std::shared_ptr<taskbar_list> taskbar_;
         std::wstring last_finished_save_path_;
         std::unique_ptr<sleep_manager> sleep_manager_;
+        std::unique_ptr<torrent_drop_target> drop_target_;
 
         core::signals::signal<void, void> on_destroy_;
         core::signals::signal<void, void> on_session_alert_notify_;

--- a/include/picotorrent/client/ui/torrent_drop_target.hpp
+++ b/include/picotorrent/client/ui/torrent_drop_target.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <picotorrent/core/signals/signal.hpp>
+
+#include <vector>
+#include <windows.h>
+
+namespace picotorrent
+{
+namespace core
+{
+namespace filesystem
+{
+    class path;
+}
+}
+namespace client
+{
+namespace ui
+{
+    class torrent_drop_target
+    {
+    public:
+        torrent_drop_target(HWND hParent);
+        ~torrent_drop_target();
+
+        core::signals::signal_connector<void, const std::vector<core::filesystem::path>&>& on_torrents_dropped();
+
+    private:
+        HWND parent_;
+        long ref_;
+        core::signals::signal<void, const std::vector<core::filesystem::path>&> on_torrents_dropped_;
+    };
+}
+}
+}

--- a/src/client/application.cpp
+++ b/src/client/application.cpp
@@ -57,6 +57,7 @@ application::application()
     main_window_->on_session_alert_notify().connect(std::bind(&application::on_session_alert_notify, this));
     main_window_->on_torrent_activated(std::bind(&application::on_torrent_activated, this, std::placeholders::_1));
     main_window_->on_torrent_context_menu(std::bind(&application::on_torrent_context_menu, this, std::placeholders::_1, std::placeholders::_2));
+    main_window_->on_torrents_dropped().connect(std::bind(&application::on_torrents_dropped, this, std::placeholders::_1));
 
     sess_->on_torrent_added().connect(std::bind(&ui::main_window::torrent_added, main_window_, std::placeholders::_1));
     sess_->on_torrent_finished().connect(std::bind(&ui::main_window::torrent_finished, main_window_, std::placeholders::_1));
@@ -305,6 +306,12 @@ void application::on_torrent_context_menu(const POINT &p, const std::vector<std:
 {
     controllers::torrent_context_menu_controller menu_controller(sess_, torrents, main_window_);
     menu_controller.execute(p);
+}
+
+void application::on_torrents_dropped(const std::vector<fs::path> &files)
+{
+    controllers::add_torrent_controller add_controller(sess_, main_window_);
+    add_controller.execute(files);
 }
 
 void application::on_view_preferences()

--- a/src/client/controllers/add_torrent_controller.cpp
+++ b/src/client/controllers/add_torrent_controller.cpp
@@ -82,6 +82,17 @@ void add_torrent_controller::execute(const command_line &cmd)
     show_add_dialog();
 }
 
+void add_torrent_controller::execute(const std::vector<fs::path> &files)
+{
+    if (files.empty())
+    {
+        return;
+    }
+
+    add_files(files);
+    show_add_dialog();
+}
+
 void add_torrent_controller::execute(const std::vector<std::shared_ptr<core::torrent_info>> &torrents)
 {
     if (torrents.empty())

--- a/src/client/ui/main_window.cpp
+++ b/src/client/ui/main_window.cpp
@@ -18,6 +18,7 @@
 #include <picotorrent/client/ui/status_bar.hpp>
 #include <picotorrent/client/ui/task_dialog.hpp>
 #include <picotorrent/client/ui/taskbar_list.hpp>
+#include <picotorrent/client/ui/torrent_drop_target.hpp>
 #include <chrono>
 #include <shellapi.h>
 #include <shlwapi.h>
@@ -48,6 +49,7 @@ using picotorrent::client::ui::open_file_dialog;
 using picotorrent::client::ui::scaler;
 using picotorrent::client::ui::taskbar_list;
 using picotorrent::client::ui::sleep_manager;
+using picotorrent::client::ui::torrent_drop_target;
 
 const UINT main_window::TaskbarButtonCreated = RegisterWindowMessage(L"TaskbarButtonCreated");
 
@@ -89,6 +91,9 @@ main_window::main_window(const std::shared_ptr<core::session> &sess)
         NULL,
         GetModuleHandle(NULL),
         static_cast<LPVOID>(this));
+
+    // Create the drop target
+    drop_target_ = std::make_unique<torrent_drop_target>(hWnd_);
 
     // Create main menu
     HMENU file = CreateMenu();
@@ -210,6 +215,11 @@ void main_window::on_torrent_activated(const std::function<void(const std::share
 void main_window::on_torrent_context_menu(const std::function<void(const POINT &p, const std::vector<std::shared_ptr<core::torrent>>&)> &callback)
 {
     torrent_context_cb_ = callback;
+}
+
+signal_connector<void, const std::vector<core::filesystem::path>&>& main_window::on_torrents_dropped()
+{
+    return drop_target_->on_torrents_dropped();
 }
 
 void main_window::post_message(UINT uMsg, WPARAM wParam, LPARAM lParam)

--- a/src/client/ui/torrent_drop_target.cpp
+++ b/src/client/ui/torrent_drop_target.cpp
@@ -29,7 +29,7 @@ public:
 #pragma warning( push )
 #pragma warning( disable : 4838 )
         static const QITAB qit[] = {
-            QITABENT(torrent_drop_target, IDropTarget),
+            QITABENT(PicoDropTarget, IDropTarget),
             { 0 }
         };
 #pragma warning( pop )

--- a/src/client/ui/torrent_drop_target.cpp
+++ b/src/client/ui/torrent_drop_target.cpp
@@ -1,0 +1,135 @@
+#include <picotorrent/client/ui/torrent_drop_target.hpp>
+
+#include <picotorrent/core/is_valid_torrent_file.hpp>
+#include <picotorrent/core/filesystem/path.hpp>
+
+#include <shellapi.h>
+#include <shlwapi.h>
+#include <shobjidl.h>
+
+#include <algorithm>
+#include <vector>
+
+namespace fs = picotorrent::core::filesystem;
+using picotorrent::client::ui::torrent_drop_target;
+using picotorrent::core::is_valid_torrent_file;
+using picotorrent::core::signals::signal;
+using picotorrent::core::signals::signal_connector;
+
+class PicoDropTarget : public IDropTarget
+{
+public:
+    PicoDropTarget(signal<void, const std::vector<fs::path>&> &dropped)
+        : on_dropped_(dropped)
+    {
+    }
+
+    IFACEMETHODIMP QueryInterface(REFIID riid, void **ppv)
+    {
+#pragma warning( push )
+#pragma warning( disable : 4838 )
+        static const QITAB qit[] = {
+            QITABENT(torrent_drop_target, IDropTarget),
+            { 0 }
+        };
+#pragma warning( pop )
+
+        return QISearch(this, qit, riid, ppv);
+    }
+
+    IFACEMETHODIMP_(ULONG) AddRef()
+    {
+        return InterlockedIncrement(&ref_);
+    }
+
+    IFACEMETHODIMP_(ULONG) Release()
+    {
+        long ref = InterlockedDecrement(&ref_);
+
+        if (!ref)
+        {
+            delete this;
+        }
+
+        return ref;
+    }
+
+    IFACEMETHODIMP_(HRESULT) DragEnter(IDataObject * pDataObject, DWORD grfKeyState, POINTL pt, DWORD * pdwEffect)
+    {
+        effect = DROPEFFECT_COPY;
+        paths_ = GetPaths(pDataObject);
+
+        if (!IsValidTorrents(paths_))
+        {
+            effect = DROPEFFECT_NONE;
+        }
+
+        *pdwEffect = effect;
+        return S_OK;
+    }
+
+    IFACEMETHODIMP_(HRESULT) DragOver(DWORD grfKeyState, POINTL pt, DWORD * pdwEffect)
+    {
+         *pdwEffect = effect;
+        return S_OK;
+    }
+
+    IFACEMETHODIMP_(HRESULT) DragLeave()
+    {
+        return S_OK;
+    }
+
+    IFACEMETHODIMP_(HRESULT) Drop(IDataObject * pDataObject, DWORD grfKeyState, POINTL pt, DWORD * pdwEffect)
+    {
+        on_dropped_.emit(paths_);
+        return S_OK;
+    }
+
+private:
+    static std::vector<fs::path> GetPaths(IDataObject *pDataObject)
+    {
+        FORMATETC fmtetc = { CF_HDROP, 0, DVASPECT_CONTENT, -1, TYMED_HGLOBAL };
+        STGMEDIUM stg;
+        pDataObject->GetData(&fmtetc, &stg);
+
+        HDROP drop = static_cast<HDROP>(stg.hGlobal);
+        int files = DragQueryFile(drop, -1, 0, 0);
+        std::vector<fs::path> paths;
+
+        for (int i = 0; i < files; i++)
+        {
+            TCHAR path[MAX_PATH];
+            DragQueryFile(drop, i, path, ARRAYSIZE(path));
+            paths.push_back(path);
+        }
+
+        return paths;
+    }
+
+    static bool IsValidTorrents(const std::vector<fs::path> &paths)
+    {
+        return std::all_of(paths.begin(), paths.end(), [](const fs::path &p) { return is_valid_torrent_file(p); });
+    }
+
+    DWORD effect = DROPEFFECT_NONE;
+    std::vector<fs::path> paths_;
+    long ref_;
+    signal<void, const std::vector<fs::path>&>& on_dropped_;
+};
+
+torrent_drop_target::torrent_drop_target(HWND hParent)
+    : parent_(hParent)
+{
+    OleInitialize(NULL);
+    RegisterDragDrop(parent_, new PicoDropTarget(on_torrents_dropped_));
+}
+
+torrent_drop_target::~torrent_drop_target()
+{
+    RevokeDragDrop(parent_);
+}
+
+signal_connector<void, const std::vector<fs::path>&>& torrent_drop_target::on_torrents_dropped()
+{
+    return on_torrents_dropped_;
+}


### PR DESCRIPTION
This adds support for drag-and-drop operations. You can drop one or more torrent files and the add torrent dialog will open. File validation is implemented and only torrent files are let through.

Closes #193 