### PR TITLE
Only log to file when debug or requested.

### DIFF
--- a/src/core/logging/log.cpp
+++ b/src/core/logging/log.cpp
@@ -34,6 +34,24 @@ picotorrent::core::logging::log& log::instance()
 
 void log::init()
 {
+    bool is_debug = true;
+
+#ifdef NDEBUG
+    is_debug = false;
+#endif
+
+    SetUnhandledExceptionFilter(
+        &log::on_unhandled_exception);
+
+    // Only do the following if we have a debug build
+    // or passed --enable-logging on the command line
+    std::wstring cmd = GetCommandLine();
+    if (!is_debug && cmd.find(L"--enable-logging") == std::wstring::npos)
+    {
+        out_ = std::make_unique<std::ostringstream>();
+        return;
+    }
+
     DWORD pid = GetCurrentProcessId();
 
     fs::path data = environment::get_data_path();


### PR DESCRIPTION
This disables logging to file in release builds. Logging can be optionally enabled for release builds by passing `--enable-logging` on the command line, either by launching from a command prompt or by editing the PicoTorrent shortcut.

Closes #197 