### PR TITLE
Add seeds/peers to torrent list.

### DIFF
--- a/include/picotorrent/core/torrent.hpp
+++ b/include/picotorrent/core/torrent.hpp
@@ -77,6 +77,8 @@ namespace core
         DLL_EXPORT int max_uploads() const;
         DLL_EXPORT void move_storage(const std::string &path);
         DLL_EXPORT std::string& name() const;
+        DLL_EXPORT int connected_nonseeds() const;
+        DLL_EXPORT int connected_seeds() const;
         DLL_EXPORT void pause();
         DLL_EXPORT float progress() const;
         DLL_EXPORT int queue_position();
@@ -96,6 +98,8 @@ namespace core
         DLL_EXPORT int64_t size();
         DLL_EXPORT torrent_state state();
         DLL_EXPORT std::shared_ptr<const torrent_info> torrent_info() const;
+        DLL_EXPORT int total_nonseeds() const;
+        DLL_EXPORT int total_seeds() const;
         DLL_EXPORT uint64_t total_wanted();
         DLL_EXPORT uint64_t total_wanted_done();
         DLL_EXPORT int upload_limit() const;

--- a/lang/1033.json
+++ b/lang/1033.json
@@ -152,6 +152,7 @@
         "top": "Top",
         "bottom": "Bottom",
         "remove_tracker_s": "Remove tracker(s)",
-        "add_tracker": "Add tracker"
+        "add_tracker": "Add tracker",
+        "seeds": "Seeds"
     }
 }

--- a/src/client/ui/main_window.cpp
+++ b/src/client/ui/main_window.cpp
@@ -35,6 +35,8 @@
 #define COLUMN_ETA 6
 #define COLUMN_DL 7
 #define COLUMN_UL 8
+#define COLUMN_SEEDS 9
+#define COLUMN_PEERS 10
 
 namespace core = picotorrent::core;
 namespace fs = picotorrent::core::filesystem;
@@ -377,6 +379,8 @@ LRESULT main_window::wnd_proc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam
         list_view_->add_column(COLUMN_ETA,            TR("eta"),            scaler::x(80),  list_view::number);
         list_view_->add_column(COLUMN_DL,             TR("dl"),             scaler::x(80),  list_view::number);
         list_view_->add_column(COLUMN_UL,             TR("ul"),             scaler::x(80),  list_view::number);
+        list_view_->add_column(COLUMN_SEEDS,          TR("seeds"),          scaler::x(80),  list_view::number);
+        list_view_->add_column(COLUMN_PEERS,          TR("peers"),          scaler::x(80),  list_view::number);
 
         noticon_ = std::make_shared<notify_icon>(hWnd);
         noticon_->add();
@@ -655,6 +659,18 @@ std::wstring main_window::on_list_display(const std::pair<int, int> &p)
         StrFormatByteSize64(rate, speed, ARRAYSIZE(speed));
         StringCchPrintf(speed, ARRAYSIZE(speed), L"%s/s", speed);
         return speed;
+    }
+    case COLUMN_SEEDS:
+    {
+        TCHAR seeds[1024];
+        StringCchPrintf(seeds, ARRAYSIZE(seeds), L"%d (%d)", t->connected_seeds(), t->total_seeds());
+        return seeds;
+    }
+    case COLUMN_PEERS:
+    {
+        TCHAR peers[1024];
+        StringCchPrintf(peers, ARRAYSIZE(peers), L"%d (%d)", t->connected_nonseeds(), t->total_nonseeds());
+        return peers;
     }
     }
 

--- a/src/core/torrent.cpp
+++ b/src/core/torrent.cpp
@@ -173,6 +173,16 @@ std::string& torrent::name() const
     return status_->name;
 }
 
+int torrent::connected_nonseeds() const
+{
+    return status_->num_peers - status_->num_seeds;
+}
+
+int torrent::connected_seeds() const
+{
+    return status_->num_seeds;
+}
+
 void torrent::pause()
 {
     if (is_paused())
@@ -296,6 +306,16 @@ std::shared_ptr<const torrent_info> torrent::torrent_info() const
     }
 
     return std::make_shared<core::torrent_info>(*status_->handle.torrent_file());
+}
+
+int torrent::total_nonseeds() const
+{
+    return status_->list_peers - status_->list_seeds;
+}
+
+int torrent::total_seeds() const
+{
+    return status_->list_seeds;
 }
 
 uint64_t torrent::total_wanted()


### PR DESCRIPTION
This adds two columns to the torrent list view which shows connected seeds/total seeds and connected peers/total peers.

Closes #187