### PR TITLE
Fixed cleaning up peers and trackers list view items

### DIFF
--- a/src/client/ui/property_sheets/details/peers_page.cpp
+++ b/src/client/ui/property_sheets/details/peers_page.cpp
@@ -31,7 +31,7 @@ struct peers_page::peer_state
     }
 
     peer peer;
-    bool dirty = false;
+    bool dirty;
 };
 
 peers_page::peers_page()
@@ -48,6 +48,11 @@ peers_page::~peers_page()
 
 void peers_page::refresh(const std::vector<peer> &peers)
 {
+    for (peer_state &ps : peers_)
+    {
+        ps.dirty = false;
+    }
+
     for (const peer &p : peers)
     {
         // TODO: std::find_if uses moderate CPU here, and in a loop as well. maybe a std::map is better for peers_.

--- a/src/client/ui/property_sheets/details/trackers_page.cpp
+++ b/src/client/ui/property_sheets/details/trackers_page.cpp
@@ -40,7 +40,7 @@ struct trackers_page::tracker_state
 
     tracker tracker;
     tracker_status status;
-    bool dirty = false;
+    bool dirty;
 };
 
 trackers_page::trackers_page()
@@ -57,6 +57,11 @@ trackers_page::~trackers_page()
 
 void trackers_page::refresh(const std::shared_ptr<torrent> &torrent)
 {
+    for (tracker_state &ts : trackers_)
+    {
+        ts.dirty = false;
+    }
+
     for (const tracker &t : torrent->get_trackers())
     {
         tracker_status &ts = torrent->get_tracker_status(t.url());


### PR DESCRIPTION
Reverts part of commit c8bca6c, which caused dead/unwanted items to not get removed from the peers and trackers tab in the details view. (unless you close and reopen the details view)

For example, peers that are no longer connected don't get removed (their stats get frozen), and trackers that you manually remove with the context menu.