### PR TITLE
Remove dependency on HWND for alert notify

### DIFF
--- a/include/picotorrent/core/session.hpp
+++ b/include/picotorrent/core/session.hpp
@@ -3,9 +3,7 @@
 #include <functional>
 #include <map>
 #include <memory>
-#include <thread>
 #include <vector>
-#include <windows.h>
 
 #include <picotorrent/common.hpp>
 #include <picotorrent/core/signals/signal.hpp>
@@ -46,7 +44,7 @@ namespace core
         DLL_EXPORT void get_metadata(const std::string &magnet_link);
         DLL_EXPORT std::shared_ptr<session_metrics> metrics();
 
-        DLL_EXPORT void load(HWND hWnd);
+        DLL_EXPORT void load();
         DLL_EXPORT void unload();
 
         DLL_EXPORT void notify();
@@ -56,13 +54,13 @@ namespace core
         DLL_EXPORT void remove_torrent(const std::shared_ptr<torrent> &torrent, bool remove_data = false);
 
         DLL_EXPORT core::signals::signal_connector<void, const std::shared_ptr<torrent_info>&>& on_metadata_received();
+        DLL_EXPORT core::signals::signal_connector<void, void>& on_notifications_available();
         DLL_EXPORT core::signals::signal_connector<void, const std::shared_ptr<torrent>&>& on_torrent_added();
         DLL_EXPORT core::signals::signal_connector<void, const std::shared_ptr<torrent>&>& on_torrent_finished();
         DLL_EXPORT core::signals::signal_connector<void, const std::shared_ptr<torrent>&>& on_torrent_removed();
         DLL_EXPORT core::signals::signal_connector<void, const std::shared_ptr<torrent>&>& on_torrent_updated();
 
     protected:
-        void on_alert_notify();
         void on_load_torrent(const libtorrent::sha1_hash &hash, std::vector<char> &buf, libtorrent::error_code &ec);
 
     private:
@@ -86,10 +84,8 @@ namespace core
         session_ptr sess_;
         std::shared_ptr<session_metrics> metrics_;
 
-        // Handle to our main window
-        HWND hWnd_;
-
         // Signals
+        core::signals::signal<void, void> on_notifications_available_;
         core::signals::signal<void, const std::shared_ptr<torrent_info>&> on_metadata_received_;
         core::signals::signal<void, const torrent_ptr&> on_torrent_added_;
         core::signals::signal<void, const torrent_ptr&> on_torrent_finished_;

--- a/src/client/application.cpp
+++ b/src/client/application.cpp
@@ -59,6 +59,11 @@ application::application()
     main_window_->on_torrent_context_menu(std::bind(&application::on_torrent_context_menu, this, std::placeholders::_1, std::placeholders::_2));
     main_window_->on_torrents_dropped().connect(std::bind(&application::on_torrents_dropped, this, std::placeholders::_1));
 
+    sess_->on_notifications_available().connect([this]()
+    {
+        PostMessage(main_window_->handle(), WM_USER + 1337, NULL, NULL);
+    });
+
     sess_->on_torrent_added().connect(std::bind(&ui::main_window::torrent_added, main_window_, std::placeholders::_1));
     sess_->on_torrent_finished().connect(std::bind(&ui::main_window::torrent_finished, main_window_, std::placeholders::_1));
     sess_->on_torrent_removed().connect(std::bind(&ui::main_window::torrent_removed, main_window_, std::placeholders::_1));
@@ -162,7 +167,7 @@ int application::run(const std::wstring &args)
         ShowWindow(main_window_->handle(), pos);
     }
 
-    sess_->load(main_window_->handle());
+    sess_->load();
 
     if (!args.empty())
     {


### PR DESCRIPTION
A small step towards cross platform compatibility for PicoTorrentCore.

References #149