### PR TITLE
Fix single application instance

### DIFF
--- a/src/core/environment.cpp
+++ b/src/core/environment.cpp
@@ -2,6 +2,7 @@
 
 #include <picotorrent/core/filesystem/path.hpp>
 #include <shlobj.h>
+#include <shlwapi.h>
 
 namespace fs = picotorrent::core::filesystem;
 using picotorrent::core::environment;
@@ -14,7 +15,8 @@ fs::path environment::get_data_path()
     }
 
     TCHAR buf[MAX_PATH];
-    GetCurrentDirectory(MAX_PATH, buf);
+    GetModuleFileName(NULL, buf, ARRAYSIZE(buf));
+    PathRemoveFileSpec(buf);
 
     return buf;
 }


### PR DESCRIPTION
Moved `sess_` and `main_window_` definition and connections from the application constructor to the `init` function.

From what I can tell after some quick testing, creating a new session / mainwindow when constructing the app before `is_single_instance` / `activate_other_instance` could run in [main.cpp#L20](https://github.com/picotorrent/picotorrent/blob/develop/src/main.cpp#L20) caused some kind of conflict with the already running session and crashes.

I also added a check to see if the command line arg string is empty before we attempt to use it in `activate_other_instance`, otherwise the client would crash if you attempted to open a new instance using the base PicoTorrent.exe without any arguments (instead of activating the current instance)

I'll post the test build links on gitter and wait for feedback from @koen-github and @enr00ted  to see if it fixes their problems. (it seems to solve the issue on my end)