### PR TITLE
Remove OpenSSL, static runtime, update libtorrent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,10 +30,6 @@ endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
 configure_file("${CMAKE_SOURCE_DIR}/src/core/version_info.cpp.in" "${CMAKE_SOURCE_DIR}/src/core/version_info.cpp" @ONLY)
 
-set(BOOST_ROOT      $ENV{BOOST_ROOT})
-set(LIBTORRENT_ROOT $ENV{LIBTORRENT_ROOT})
-set(OPENSSL_ROOT    $ENV{OPENSSL_ROOT})
-
 set(PICOTORRENTCORE_SOURCES
     # File system components
     src/core/filesystem/directory
@@ -114,11 +110,16 @@ set(PICOTORRENT_SOURCES
     src/client/ui/torrent_drop_target
 )
 
+# Shared flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WX")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WX")
 
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
+# Debug flags
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd /Zi")
+
+# Release flags
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT /Zi")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/DEBUG /INCREMENTAL:NO /MAP /OPT:REF /OPT:ICF")
 set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "/DEBUG /INCREMENTAL:NO /MAP /OPT:REF /OPT:ICF")
 
@@ -139,7 +140,6 @@ add_definitions(
     -DNOMINMAX
     -DPICOJSON_USE_INT64
     -DTORRENT_NO_DEPRECATE
-    -DTORRENT_USE_OPENSSL
     -DUNICODE
     -DWIN32
     -DWIN32_LEAN_AND_MEAN
@@ -170,20 +170,16 @@ target_link_libraries(
     shlwapi
 
     # Boost.Random
-    debug     libboost_random-vc140-mt-gd-1_60
-    optimized libboost_random-vc140-mt-1_60
+    debug     libboost_random-vc140-mt-sgd-1_60
+    optimized libboost_random-vc140-mt-s-1_60
 
     # Boost.System
-    debug     libboost_system-vc140-mt-gd-1_60
-    optimized libboost_system-vc140-mt-1_60
-
-    # OpenSSL
-    libeay32
-    ssleay32
+    debug     libboost_system-vc140-mt-sgd-1_60
+    optimized libboost_system-vc140-mt-s-1_60
 
     # Rasterbar-libtorrent
-    debug     libtorrent-vc140-mt-gd
-    optimized libtorrent-vc140-mt
+    debug     libtorrent-vc140-mt-sgd
+    optimized libtorrent-vc140-mt-s
 )
 
 target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ add_definitions(
 
 add_library(
     PicoTorrentCore
-    SHARED
+    STATIC
     ${PICOTORRENTCORE_SOURCES}
 )
 

--- a/build.cake
+++ b/build.cake
@@ -99,8 +99,7 @@ Task("Setup-Publish-Directory")
 {
     var files = new FilePath[]
     {
-        BuildDirectory + File("PicoTorrent.exe"),
-        BuildDirectory + File("PicoTorrentCore.dll")
+        BuildDirectory + File("PicoTorrent.exe")
     };
 
     CreateDirectory(PublishDirectory);
@@ -185,8 +184,7 @@ Task("Build-Symbols-Package")
 {
     var files = new FilePath[]
     {
-        BuildDirectory + File("PicoTorrent.pdb"),
-        BuildDirectory + File("PicoTorrentCore.pdb")
+        BuildDirectory + File("PicoTorrent.pdb")
     };
 
     Zip(BuildDirectory, BuildDirectory + File(SymbolsPackage), files);
@@ -221,7 +219,6 @@ Task("Sign")
     .Does(() =>
 {
     SignTool(BuildDirectory + File("PicoTorrent.exe"));
-    SignTool(BuildDirectory + File("PicoTorrentCore.dll"));
 });
 
 Task("Sign-Installer")

--- a/build.cake
+++ b/build.cake
@@ -19,7 +19,6 @@ var Version            = System.IO.File.ReadAllText("VERSION").Trim();
 var Installer          = string.Format("PicoTorrent-{0}-{1}.msi", Version, platform);
 var InstallerBundle    = string.Format("PicoTorrent-{0}-{1}.exe", Version, platform);
 var PortablePackage    = string.Format("PicoTorrent-{0}-{1}.zip", Version, platform);
-var PortableBundle     = string.Format("PicoTorrent-{0}-{1}.portable.zip", Version, platform);
 var SymbolsPackage     = string.Format("PicoTorrent-{0}-{1}.symbols.zip", Version, platform);
 
 public void SignTool(FilePath file)
@@ -110,45 +109,6 @@ Task("Setup-Publish-Directory")
     DeleteFile(PublishDirectory + Directory("lang") + File("1033.json"));
 });
 
-Task("Setup-Portable-Bundle")
-    .IsDependentOn("Setup-Publish-Directory")
-    .Does(() =>
-{
-    var VCRedist = Directory("C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\redist");
-    var VCDir = VCRedist + Directory(platform) + Directory("Microsoft.VC140.CRT");
-
-    var CRTRedist = Directory("C:\\Program Files (x86)\\Windows Kits\\10\\Redist\\ucrt\\DLLs");
-    var CRTDir = CRTRedist + Directory(platform);
-
-    var files = new FilePath[]
-    {
-        VCDir + File("msvcp140.dll"),
-        VCDir + File("vcruntime140.dll"),
-        CRTDir + File("api-ms-win-core-file-l1-2-0.dll"),
-        CRTDir + File("api-ms-win-core-file-l2-1-0.dll"),
-        CRTDir + File("api-ms-win-core-localization-l1-2-0.dll"),
-        CRTDir + File("api-ms-win-core-processthreads-l1-1-1.dll"),
-        CRTDir + File("api-ms-win-core-synch-l1-2-0.dll"),
-        CRTDir + File("api-ms-win-core-timezone-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-conio-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-convert-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-environment-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-filesystem-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-heap-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-locale-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-math-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-multibyte-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-runtime-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-stdio-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-string-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-time-l1-1-0.dll"),
-        CRTDir + File("api-ms-win-crt-utility-l1-1-0.dll"),
-        CRTDir + File("ucrtbase.dll")
-    };
-
-    CopyFiles(files, PublishDirectory);
-});
-
 Task("Build-Installer")
     .IsDependentOn("Build")
     .IsDependentOn("Setup-Publish-Directory")
@@ -217,14 +177,6 @@ Task("Build-Portable-Package")
     .Does(() =>
 {
     Zip(PublishDirectory, BuildDirectory + File(PortablePackage));
-});
-
-Task("Build-Portable-Bundle")
-    .IsDependentOn("Build-Portable-Package")
-    .IsDependentOn("Setup-Portable-Bundle")
-    .Does(() =>
-{
-    Zip(PublishDirectory, BuildDirectory + File(PortableBundle));
 });
 
 Task("Build-Symbols-Package")
@@ -311,8 +263,7 @@ Task("Default")
     .IsDependentOn("Build-Installer-Bundle")
     .IsDependentOn("Build-Chocolatey-Package")
     .IsDependentOn("Build-Portable-Package")
-    .IsDependentOn("Build-Symbols-Package")
-    .IsDependentOn("Build-Portable-Bundle");
+    .IsDependentOn("Build-Symbols-Package");
 
 Task("Publish")
     .IsDependentOn("Build")
@@ -323,8 +274,7 @@ Task("Publish")
     .IsDependentOn("Sign-Installer-Bundle")
     .IsDependentOn("Build-Chocolatey-Package")
     .IsDependentOn("Build-Portable-Package")
-    .IsDependentOn("Build-Symbols-Package")
-    .IsDependentOn("Build-Portable-Bundle");
+    .IsDependentOn("Build-Symbols-Package");
 
 //////////////////////////////////////////////////////////////////////
 // EXECUTION

--- a/include/picotorrent/common.hpp
+++ b/include/picotorrent/common.hpp
@@ -1,3 +1,7 @@
 #pragma once
 
-#define DLL_EXPORT __declspec(dllexport)
+#ifdef PICOCORE_DLL
+    #define DLL_EXPORT __declspec(dllexport)
+#else
+    #define DLL_EXPORT
+#endif

--- a/installer/PicoTorrent.wxs
+++ b/installer/PicoTorrent.wxs
@@ -34,7 +34,6 @@
 
                     <Component Id="C_PicoTorrent" Guid="5eb6d6ac-dc76-4fac-80ff-f31a4c05f205">
                         <File Id="F_PicoTorrent.exe" Name="PicoTorrent.exe" Source="$(var.PublishDirectory)\PicoTorrent.exe" KeyPath="yes" />
-                        <File Id="F_PicoTorrentCore.dll" Name="PicoTorrentCore.dll" Source="$(var.PublishDirectory)\PicoTorrentCore.dll" />
 
                         <!-- Shortcut -->
                         <Shortcut Id="S_PicoTorrent"

--- a/installer/PicoTorrentBundle.wxs
+++ b/installer/PicoTorrentBundle.wxs
@@ -1,27 +1,11 @@
 <?xml version="1.0"?>
 
 <?if $(var.Platform) = "x64" ?>
-    <?define FindVCRedistKey = "Software\Wow6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" ?>
     <?define InstallFolder = "[ProgramFiles64Folder]PicoTorrent" ?>
     <?define UpgradeCode = "58903cac-fb00-4335-8149-0e1177cc8cba" ?>
-
-    <?define VCRedistDescription = "Microsoft Visual C++ 2015 Redistributable (x64) - 14.0.23026" ?>
-    <?define VCRedistHash = "3155cb0f146b927fcc30647c1a904cd162548c8c" ?>
-    <?define VCRedistName = "vc_redist.x64.exe" ?>
-    <?define VCRedistSize = "14573568" ?>
-    <?define VCRedistUrl = "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe" ?>
-    <?define VCRedistVersion = "14.0.23026.0" ?>
 <?else ?>
-    <?define FindVCRedistKey = "Software\Microsoft\VisualStudio\14.0\VC\Runtimes\x86" ?>
     <?define InstallFolder = "[ProgramFilesFolder]PicoTorrent" ?>
     <?define UpgradeCode = "08b52a3a-63eb-47c0-8a75-1df052a99042" ?>
-
-    <?define VCRedistDescription = "Microsoft Visual C++ 2015 Redistributable (x86) - 14.0.23026" ?>
-    <?define VCRedistHash = "bfb74e498c44d3a103ca3aa2831763fb417134d1" ?>
-    <?define VCRedistName = "vc_redist.x86.exe" ?>
-    <?define VCRedistSize = "13767776" ?>
-    <?define VCRedistUrl = "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe" ?>
-    <?define VCRedistVersion = "14.0.23026.0" ?>
 <?endif ?>
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
@@ -35,14 +19,6 @@
             UpgradeCode="$(var.UpgradeCode)"
             Version="$(var.Version)">
 
-        <!-- Search for the C++ redistributable -->
-        <util:RegistrySearch Id="FindVCRedist"
-                             Root="HKLM"
-                             Key="$(var.FindVCRedistKey)"
-                             Value="installed"
-                             Variable="VCRedistExists"
-                             Result="exists" />
-
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">
             <bal:WixStandardBootstrapperApplication LicenseFile="LICENSE.rtf"
                                                     LogoFile="res/app.png" />
@@ -52,25 +28,6 @@
         <Variable Name="LaunchTarget" Value="[InstallFolder]\PicoTorrent.exe"/>
 
         <Chain>
-            <ExePackage Name="$(var.VCRedistName)"
-                        Compressed="no"
-                        DetectCondition="VCRedistExists"
-                        DownloadUrl="$(var.VCRedistUrl)"
-                        InstallCommand="/quiet"
-                        PerMachine="yes"
-                        Permanent="yes"
-                        Vital="yes">
-
-                <RemotePayload
-                               Description="$(var.VCRedistDescription)"
-                               Hash="$(var.VCRedistHash)"
-                               ProductName="$(var.VCRedistDescription)"
-                               Size="$(var.VCRedistSize)"
-                               Version="$(var.VCRedistVersion)" />
-            </ExePackage>
-
-            <RollbackBoundary />
-
             <MsiPackage Id="PicoTorrentPackage"
                         Compressed="yes"
                         SourceFile="$(var.PicoTorrentInstaller)">

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Cake" version="0.8.0" />
   <package id="Cake.CMake" version="0.0.2" />
-  <package id="PicoTorrent.Libs" version="0.4.0" />
+  <package id="PicoTorrent.Libs" version="0.6.0" />
   <package id="WiX.Toolset" version="3.9.1208" />
 </packages>


### PR DESCRIPTION
This PR makes Pico link statically against the MSVC runtime removing the need to install the runtime. It also removes OpenSSL since we do not use it, as well as updates libtorrent to the latest master head (b16f43132b721b522e322f1545eb60f5cb36865e)

Closes #214 