### PR TITLE
Center text in progress bar display.

### DIFF
--- a/src/client/ui/controls/list_view.cpp
+++ b/src/client/ui/controls/list_view.cpp
@@ -384,7 +384,7 @@ LRESULT list_view::subclass_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
 
                 TCHAR progress_str[100];
                 StringCchPrintf(progress_str, ARRAYSIZE(progress_str), TEXT("%.2f%%"), val * 100);
-                DrawText(hDc, progress_str, -1, &text, DT_CENTER | DT_VCENTER);
+                DrawText(hDc, progress_str, -1, &text, DT_CENTER | DT_SINGLELINE | DT_VCENTER);
 
                 return CDRF_SKIPDEFAULT;
             }


### PR DESCRIPTION
`DT_VCENTER` only works when `DT_SINGLELINE` is also flagged according to [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/dd162498(v=vs.85).aspx).

![](http://i.imgur.com/NL0sY51.png)