### PR TITLE
Change to a permanent peer ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,25 @@ Rasterbar-libtorrent to provide high performance and low memory usage.
 
 ![](https://cdn.rawgit.com/picotorrent/picotorrent.github.io/master/img/screenshots/picotorrent1.png)
 
+
+## Quick facts
+
+- (Azureus-style) peer ID: `-PI-`. Example: `-PI0091-` (major: 0, minor: 09, patch: 1).
+- User agent: `PicoTorrent/x.y.z`.
+- The x86 executable is less than 1MB if compressed with UPX.
+- Native look-and-feel across Windows versions.
+- Support for magnet link pre-loading.
+
+
 ## Building PicoTorrent
 
 PicoTorrent depends only on what Rasterbar-libtorrent needs (Boost.System,
-Boost.Random, and OpenSSL) and all dependencies are conveniently pre-packaged
-in a NuGet package which will be downloaded as a part of the build process.
+and Boost.Random) and all dependencies are conveniently pre-packaged in a
+NuGet package which will be downloaded as a part of the build process.
 
 To successfully build PicoTorrent, you need the following tools installed,
 
-- CMake (>= v2.8) (installed & added to PATH)
+- CMake (>= v2.8) (installed and added to `PATH`)
 - Visual Studio 2015 (Community edition) (with C++ toolset installed)
 - Chocolatey (>= v0.9.9.11)
 
@@ -25,6 +35,7 @@ Build PicoTorrent by running the following in a PowerShell prompt,
 ```
 PS> .\build.ps1
 ```
+
 
 ## License
 

--- a/include/picotorrent/client/configuration.hpp
+++ b/include/picotorrent/client/configuration.hpp
@@ -132,9 +132,6 @@ namespace client
         int upload_rate_limit();
         void set_upload_rate_limit(int ul_rate);
 
-        bool use_picotorrent_peer_id();
-        void set_use_picotorrent_peer_id(bool value);
-
         std::shared_ptr<placement> window_placement(const std::string &name);
         void set_window_placement(const std::string &name, const placement &wnd);
 

--- a/include/picotorrent/core/session_configuration.hpp
+++ b/include/picotorrent/core/session_configuration.hpp
@@ -42,7 +42,6 @@ namespace core
         std::string temporary_directory;
         std::string torrents_directory;
         int upload_rate_limit;
-        bool use_picotorrent_peer_id;
 
         // Proxy settings
         proxy_type_t proxy_type;

--- a/src/client/configuration.cpp
+++ b/src/client/configuration.cpp
@@ -262,7 +262,6 @@ std::shared_ptr<session_configuration> configuration::session_configuration()
     cfg->temporary_directory = environment::get_temporary_directory();
     cfg->torrents_directory = pal::combine_paths(environment::get_data_path(), "Torrents");
     cfg->upload_rate_limit = upload_rate_limit();
-    cfg->use_picotorrent_peer_id = use_picotorrent_peer_id();
 
     // Proxy
     cfg->proxy_force = proxy_force();
@@ -304,16 +303,6 @@ int configuration::upload_rate_limit()
 void configuration::set_upload_rate_limit(int ul_rate)
 {
     set("global_ul_rate_limit", ul_rate);
-}
-
-bool configuration::use_picotorrent_peer_id()
-{
-    return get_or_default("use_picotorrent_peer_id", false);
-}
-
-void configuration::set_use_picotorrent_peer_id(bool value)
-{
-    set("use_picotorrent_peer_id", value);
 }
 
 template<typename T>

--- a/src/client/controllers/view_preferences_controller.cpp
+++ b/src/client/controllers/view_preferences_controller.cpp
@@ -64,8 +64,8 @@ void view_preferences_controller::execute()
     {
         *gen_page_,
         *dl_page_,
-        *conn_page_,
-        *adv_page_
+        *conn_page_
+        //*adv_page_
     };
 
     PROPSHEETHEADER header = { 0 };
@@ -91,13 +91,11 @@ void view_preferences_controller::execute()
 void view_preferences_controller::on_advanced_apply()
 {
     configuration &cfg = configuration::instance();
-    cfg.set_use_picotorrent_peer_id(adv_page_->use_picotorrent_id());
 }
 
 void view_preferences_controller::on_advanced_init()
 {
     configuration &cfg = configuration::instance();
-    adv_page_->set_use_picotorrent_id(cfg.use_picotorrent_peer_id());
 }
 
 void view_preferences_controller::on_downloads_apply()

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -250,26 +250,17 @@ std::shared_ptr<lt::settings_pack> session::get_session_settings()
     settings->set_int(lt::settings_pack::download_rate_limit, config_->download_rate_limit);
     settings->set_int(lt::settings_pack::upload_rate_limit, config_->upload_rate_limit);
 
-    // Set PicoTorrent peer id and user agent
-    if (config_->use_picotorrent_peer_id)
-    {
-        // Calculate user agent
-        std::stringstream user_agent;
-        user_agent << "PicoTorrent/" << version_info::current_version();
+    // Calculate user agent
+    std::stringstream user_agent;
+    user_agent << "PicoTorrent/" << version_info::current_version();
 
-        // Calculate peer id
-        semver::version v(version_info::current_version());
-        std::stringstream peer_id;
-        peer_id << "-PI" << v.getMajor() << std::setfill('0') << std::setw(2) << v.getMinor() << v.getPatch() << "-";
+    // Calculate peer id
+    semver::version v(version_info::current_version());
+    std::stringstream peer_id;
+    peer_id << "-PI" << v.getMajor() << std::setfill('0') << std::setw(2) << v.getMinor() << v.getPatch() << "-";
 
-        settings->set_str(lt::settings_pack::user_agent, user_agent.str());
-        settings->set_str(lt::settings_pack::peer_fingerprint, peer_id.str());
-    }
-    else
-    {
-        settings->set_str(lt::settings_pack::user_agent, "libtorrent/" LIBTORRENT_VERSION);
-        settings->set_str(lt::settings_pack::peer_fingerprint, "-LT1100-");
-    }
+    settings->set_str(lt::settings_pack::user_agent, user_agent.str());
+    settings->set_str(lt::settings_pack::peer_fingerprint, peer_id.str());
 
     // Proxy settings
     settings->set_int(lt::settings_pack::proxy_type, config_->proxy_type);


### PR DESCRIPTION
This will force the use of PicoTorrent's own peer ID (`-PI-`) in order to get traction among private trackers.

Closes #233 