### PR TITLE
Show warning if adding a torrent already in the session

### DIFF
--- a/include/picotorrent/core/hash.hpp
+++ b/include/picotorrent/core/hash.hpp
@@ -17,8 +17,9 @@ namespace core
     { 
     public:
         DLL_EXPORT hash(const libtorrent::sha1_hash &h);
-
         DLL_EXPORT std::string to_string();
+
+        operator libtorrent::sha1_hash&() const { return *hash_; }
 
     private:
         std::unique_ptr<libtorrent::sha1_hash> hash_;

--- a/include/picotorrent/core/session.hpp
+++ b/include/picotorrent/core/session.hpp
@@ -30,6 +30,7 @@ namespace picotorrent
 namespace core
 {
     class add_request;
+    class hash;
     struct session_configuration;
     class session_metrics;
     class torrent;
@@ -43,6 +44,7 @@ namespace core
 
         DLL_EXPORT void add_torrent(const std::shared_ptr<add_request> &add);
         DLL_EXPORT void get_metadata(const std::string &magnet_link);
+        DLL_EXPORT bool has_torrent(const std::shared_ptr<hash> &hash);
         DLL_EXPORT std::shared_ptr<session_metrics> metrics();
 
         DLL_EXPORT void load();

--- a/include/picotorrent/core/torrent_info.hpp
+++ b/include/picotorrent/core/torrent_info.hpp
@@ -14,6 +14,7 @@ namespace picotorrent
 namespace core
 {
     class add_request;
+    class hash;
     class torrent_info;
 
     typedef std::shared_ptr<torrent_info> torrent_info_ptr;
@@ -31,6 +32,7 @@ namespace core
 
         DLL_EXPORT std::string file_path(int index) const;
         DLL_EXPORT int64_t file_size(int index) const;
+        DLL_EXPORT std::shared_ptr<hash> info_hash() const;
         DLL_EXPORT std::string name();
         DLL_EXPORT int num_files() const;
         DLL_EXPORT int64_t total_size();

--- a/lang/1033.json
+++ b/lang/1033.json
@@ -153,6 +153,7 @@
         "bottom": "Bottom",
         "remove_tracker_s": "Remove tracker(s)",
         "add_tracker": "Add tracker",
-        "seeds": "Seeds"
+        "seeds": "Seeds",
+        "torrent_s_already_in_session": "Torrent(s) already in session"
     }
 }

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -1,6 +1,7 @@
 #include <picotorrent/core/session.hpp>
 
 #include <picotorrent/core/add_request.hpp>
+#include <picotorrent/core/hash.hpp>
 #include <picotorrent/core/pal.hpp>
 #include <picotorrent/core/session_configuration.hpp>
 #include <picotorrent/core/session_metrics.hpp>
@@ -37,6 +38,7 @@ namespace lt = libtorrent;
 using picotorrent::core::signals::signal;
 using picotorrent::core::signals::signal_connector;
 using picotorrent::core::add_request;
+using picotorrent::core::hash;
 using picotorrent::core::pal;
 using picotorrent::core::session;
 using picotorrent::core::session_configuration;
@@ -123,6 +125,11 @@ void session::get_metadata(const std::string &magnet)
     // Add the info hash to our list of currently requested metadata files.
     loading_metadata_.insert({ p.info_hash, nullptr });
     sess_->async_add_torrent(p);
+}
+
+bool session::has_torrent(const std::shared_ptr<hash> &hash)
+{
+    return (torrents_.find(*hash) != torrents_.end());
 }
 
 std::shared_ptr<session_metrics> session::metrics()

--- a/src/core/torrent_info.cpp
+++ b/src/core/torrent_info.cpp
@@ -1,13 +1,16 @@
 #include <picotorrent/core/torrent_info.hpp>
 
+#include <picotorrent/core/hash.hpp>
 #include <picotorrent/core/pal.hpp>
 #include <fstream>
 
 #include <picotorrent/_aux/disable_3rd_party_warnings.hpp>
+#include <libtorrent/sha1_hash.hpp>
 #include <libtorrent/torrent_info.hpp>
 #include <picotorrent/_aux/enable_3rd_party_warnings.hpp>
 
 namespace lt = libtorrent;
+using picotorrent::core::hash;
 using picotorrent::core::pal;
 using picotorrent::core::torrent_info;
 
@@ -49,6 +52,11 @@ std::string torrent_info::file_path(int index) const
 int64_t torrent_info::file_size(int index) const
 {
     return info_->files().file_size(index);
+}
+
+std::shared_ptr<hash> torrent_info::info_hash() const
+{
+    return std::make_shared<hash>(info_->info_hash());
 }
 
 std::string torrent_info::name()

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Cake" version="0.8.0" />
   <package id="Cake.CMake" version="0.0.2" />
-  <package id="PicoTorrent.Libs" version="0.6.0" />
+  <package id="PicoTorrent.Libs" version="0.7.0" />
   <package id="WiX.Toolset" version="3.9.1208" />
 </packages>


### PR DESCRIPTION
This shows a simple warning if one adds one or more torrents already in the session.

Closes #232 