### PR TITLE
Restore OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ add_definitions(
     -DBOOST_ALL_NO_LIB
     -DPICOJSON_USE_INT64
     -DTORRENT_NO_DEPRECATE
+    -DTORRENT_USE_OPENSSL
 )
 
 # WIN32 definitions
@@ -191,6 +192,10 @@ target_link_libraries(
     # Rasterbar-libtorrent
     debug     libtorrent-vc140-mt-sgd
     optimized libtorrent-vc140-mt-s
+
+    # OpenSSL
+    libeay32
+    ssleay32
 )
 
 if(WIN32)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Rasterbar-libtorrent to provide high performance and low memory usage.
 
 - (Azureus-style) peer ID: `-PI-`. Example: `-PI0091-` (major: 0, minor: 09, patch: 1).
 - User agent: `PicoTorrent/x.y.z`.
-- The x86 executable is less than 1MB if compressed with UPX.
+- The x86 executable is less than 1.5MB if compressed with UPX.
 - Native look-and-feel across Windows versions.
 - Support for magnet link pre-loading.
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Cake" version="0.8.0" />
   <package id="Cake.CMake" version="0.0.2" />
-  <package id="PicoTorrent.Libs" version="0.7.0" />
+  <package id="PicoTorrent.Libs" version="0.8.0" />
   <package id="WiX.Toolset" version="3.9.1208" />
 </packages>


### PR DESCRIPTION
Bring back OpenSSL which was used to support HTTPS trackers.