### PR TITLE
Center property sheets and dialogs on their parents

### DIFF
--- a/src/client/ui/dialogs/dialog_base.cpp
+++ b/src/client/ui/dialogs/dialog_base.cpp
@@ -96,6 +96,34 @@ INT_PTR dialog_base::dlg_proc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
     case WM_INITDIALOG:
     {
         handle_ = hwndDlg;
+
+        // Center dialog on parent
+        HWND hParent = NULL;
+
+        if ((hParent = GetParent(hwndDlg)) == NULL)
+        {
+            hParent = GetDesktopWindow();
+        }
+
+        RECT rcOwner;
+        RECT rcDlg;
+        RECT rc;
+
+        GetWindowRect(hParent, &rcOwner);
+        GetWindowRect(hwndDlg, &rcDlg);
+        CopyRect(&rc, &rcOwner);
+
+        OffsetRect(&rcDlg, -rcDlg.left, -rcDlg.top);
+        OffsetRect(&rc, -rc.left, -rc.top);
+        OffsetRect(&rc, -rcDlg.right, -rcDlg.bottom);
+
+        SetWindowPos(hwndDlg,
+            HWND_TOP,
+            rcOwner.left + (rc.right / 2),
+            rcOwner.top + 20,
+            0, 0,
+            SWP_NOSIZE);
+
         return on_init_dialog();
     }
 

--- a/src/client/ui/property_sheets/property_sheet_page.cpp
+++ b/src/client/ui/property_sheets/property_sheet_page.cpp
@@ -39,7 +39,30 @@ INT_PTR property_sheet_page::dlg_proc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
     }
 
     case WM_INITDIALOG:
+    {
         handle_ = hwndDlg;
+
+        // Center dialog on parent
+        HWND hParent = GetParent(hwndDlg);
+        HWND hBase = GetParent(hParent);
+        RECT rcOwner;
+        RECT rcDlg;
+        RECT rc;
+
+        GetWindowRect(hBase, &rcOwner);
+        GetWindowRect(hParent, &rcDlg);
+        CopyRect(&rc, &rcOwner);
+
+        OffsetRect(&rcDlg, -rcDlg.left, -rcDlg.top);
+        OffsetRect(&rc, -rc.left, -rc.top);
+        OffsetRect(&rc, -rcDlg.right, -rcDlg.bottom);
+
+        SetWindowPos(hParent,
+            HWND_TOP,
+            rcOwner.left + (rc.right / 2),
+            rcOwner.top + 20,
+            0, 0,
+            SWP_NOSIZE);
 
         is_initializing_ = true;
         on_init_dialog();
@@ -47,6 +70,7 @@ INT_PTR property_sheet_page::dlg_proc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LP
         is_initializing_ = false;
 
         return TRUE;
+    }
 
     case WM_NOTIFY:
         LPNMHDR pnmh = (LPNMHDR)lParam;


### PR DESCRIPTION
A simple PR to center dialogs and property sheets on their parents, like the task dialogs do.

Closes #231 