### PR TITLE
Use shared libraries (.dll) everywhere.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,6 @@ link_directories(
 
 add_definitions(
     -DBOOST_ALL_NO_LIB
-    -DPICOCORE_DLL
     -DPICOJSON_USE_INT64
     -DTORRENT_NO_DEPRECATE
     -DTORRENT_USE_OPENSSL
@@ -168,6 +167,7 @@ if(WIN32)
         -D_WIN32
         -D_WIN32_WINNT=0x0600
         -DNOMINMAX
+        -DPICOCORE_DLL
         -DUNICODE
         -DWIN32
         -DWIN32_LEAN_AND_MEAN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,10 +132,10 @@ if(WIN32)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /WX")
 
     # Debug flags
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd /Zi")
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Zi")
 
     # Release flags
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT /Zi")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/DEBUG /INCREMENTAL:NO /MAP /OPT:REF /OPT:ICF")
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "/DEBUG /INCREMENTAL:NO /MAP /OPT:REF /OPT:ICF")
 else()
@@ -149,11 +149,12 @@ include_directories(
 )
 
 link_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/tools/PicoTorrent.Libs/bin/${PICO_ARCH}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tools/PicoTorrent.Libs/bin/${PICO_ARCH}/$(Configuration)
 )
 
 add_definitions(
     -DBOOST_ALL_NO_LIB
+    -DPICOCORE_DLL
     -DPICOJSON_USE_INT64
     -DTORRENT_NO_DEPRECATE
     -DTORRENT_USE_OPENSSL
@@ -175,7 +176,7 @@ endif()
 
 add_library(
     PicoTorrentCore
-    STATIC
+    SHARED
     ${PICOTORRENTCORE_SOURCES}
 )
 
@@ -200,16 +201,15 @@ target_link_libraries(
     shlwapi
 
     # Boost.Random
-    debug     libboost_random-vc140-mt-sgd-1_60
-    optimized libboost_random-vc140-mt-s-1_60
+    debug     boost_random-vc140-mt-gd-1_60
+    optimized boost_random-vc140-mt-1_60
 
     # Boost.System
-    debug     libboost_system-vc140-mt-sgd-1_60
-    optimized libboost_system-vc140-mt-s-1_60
+    debug     boost_system-vc140-mt-gd-1_60
+    optimized boost_system-vc140-mt-1_60
 
     # Rasterbar-libtorrent
-    debug     libtorrent-vc140-mt-sgd
-    optimized libtorrent-vc140-mt-s
+    torrent
 
     # OpenSSL
     libeay32

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,18 +138,46 @@ if(WIN32)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/DEBUG /INCREMENTAL:NO /MAP /OPT:REF /OPT:ICF")
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "/DEBUG /INCREMENTAL:NO /MAP /OPT:REF /OPT:ICF")
+
+    # Win32 libraries
+    link_directories(
+        ${CMAKE_CURRENT_SOURCE_DIR}/tools/PicoTorrent.Libs/bin/${PICO_ARCH}/$(Configuration)
+    )
+
+    set(PICO_LIBS
+        dbghelp
+        iphlpapi
+        shlwapi
+
+        # Rasterbar-libtorrent
+        torrent
+
+        # OpenSSL
+        libeay32
+        ssleay32
+    )
 else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+    set(PICO_LIBS
+        # Boost
+        boost_chrono
+        boost_random
+        boost_system
+
+        # Pthread
+        pthread
+
+        # OpenSSL
+        ssl
+        crypto
+    )
 endif()
 
 include_directories(
     include/
     libs/websocketpp
     tools/PicoTorrent.Libs/include
-)
-
-link_directories(
-    ${CMAKE_CURRENT_SOURCE_DIR}/tools/PicoTorrent.Libs/bin/${PICO_ARCH}/$(Configuration)
 )
 
 add_definitions(
@@ -180,7 +208,24 @@ add_library(
     ${PICOTORRENTCORE_SOURCES}
 )
 
+target_link_libraries(
+    PicoTorrentCore
+    ${PICO_LIBS}
+)
+
 if(WIN32)
+    target_link_libraries(
+        PicoTorrentCore
+
+        # Boost Random
+        debug boost_random-vc140-mt-gd-1_60
+        optimized boost_random-vc140-mt-1_60
+
+        # Boost System
+        debug boost_system-vc140-mt-gd-1_60
+        optimized boost_system-vc140-mt-1_60
+    )
+
     add_executable(
         PicoTorrent
         WIN32
@@ -191,32 +236,7 @@ if(WIN32)
         # to avoid linker issues.
         src/client/pico.rc
     )
-endif()
 
-target_link_libraries(
-    PicoTorrentCore
-
-    dbghelp
-    iphlpapi
-    shlwapi
-
-    # Boost.Random
-    debug     boost_random-vc140-mt-gd-1_60
-    optimized boost_random-vc140-mt-1_60
-
-    # Boost.System
-    debug     boost_system-vc140-mt-gd-1_60
-    optimized boost_system-vc140-mt-1_60
-
-    # Rasterbar-libtorrent
-    torrent
-
-    # OpenSSL
-    libeay32
-    ssleay32
-)
-
-if(WIN32)
     target_link_libraries(
         PicoTorrent
 

--- a/include/picotorrent/core/pal.hpp
+++ b/include/picotorrent/core/pal.hpp
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include <picotorrent/common.hpp>
+
 namespace picotorrent
 {
 namespace core
@@ -10,13 +12,13 @@ namespace core
     class pal
     {
     public:
-        static std::string combine_paths(const std::string &p1, const std::string &p2);
-        static void create_directories(const std::string &path);
-        static bool directory_exists(const std::string &path);
-        static bool file_exists(const std::string &path);
-        static std::vector<std::string> get_directory_entries(const std::string &directory, const std::string &filter);
-        static void remove_file(const std::string &path);
-        static std::string replace_extension(const std::string &path, const std::string &new_extension);
+        DLL_EXPORT static std::string combine_paths(const std::string &p1, const std::string &p2);
+        DLL_EXPORT static void create_directories(const std::string &path);
+        DLL_EXPORT static bool directory_exists(const std::string &path);
+        DLL_EXPORT static bool file_exists(const std::string &path);
+        DLL_EXPORT static std::vector<std::string> get_directory_entries(const std::string &directory, const std::string &filter);
+        DLL_EXPORT static void remove_file(const std::string &path);
+        DLL_EXPORT static std::string replace_extension(const std::string &path, const std::string &new_extension);
     };
 }
 }

--- a/installer/PicoTorrent.wxs
+++ b/installer/PicoTorrent.wxs
@@ -8,6 +8,14 @@
     <?define UpgradeCode = "2611493f-f5d7-4c5d-934a-623c9a7c7b36" ?>
 <?endif ?>
 
+<?if $(var.Configuration) = "Debug" ?>
+    <?define BoostRandomFile = "boost_random-vc140-mt-gd-1_60.dll" ?>
+    <?define BoostSystemFile = "boost_system-vc140-mt-gd-1_60.dll" ?>
+<?else ?>
+    <?define BoostRandomFile = "boost_random-vc140-mt-1_60.dll" ?>
+    <?define BoostSystemFile = "boost_system-vc140-mt-1_60.dll" ?>
+<?endif ?>
+
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
     <Product Id="*"
         UpgradeCode="$(var.UpgradeCode)"
@@ -174,6 +182,32 @@
             <Directory Id="ProgramMenuFolder" />
         </Directory>
 
+        <ComponentGroup Id="CG_Libraries" Directory="INSTALLDIR">
+          <Component Id="C_PicoTorrentCore">
+            <File Name="PicoTorrentCore.dll" Source="$(var.PublishDirectory)\PicoTorrentCore.dll" />
+          </Component>
+
+          <Component Id="C_BoostRandom">
+            <File Name="$(var.BoostRandomFile)" Source="$(var.PublishDirectory)\$(var.BoostRandomFile)" />
+          </Component>
+
+          <Component Id="C_BoostSystem">
+            <File Name="$(var.BoostSystemFile)" Source="$(var.PublishDirectory)\$(var.BoostSystemFile)" />
+          </Component>
+
+          <Component Id="C_libeay32">
+            <File Name="libeay32.dll" Source="$(var.PublishDirectory)\libeay32.dll" />
+          </Component>
+
+          <Component Id="C_ssleay32">
+            <File Name="ssleay32.dll" Source="$(var.PublishDirectory)\ssleay32.dll" />
+          </Component>
+
+          <Component Id="C_torrent">
+            <File Name="torrent.dll" Source="$(var.PublishDirectory)\torrent.dll" />
+          </Component>
+        </ComponentGroup>
+
         <ComponentGroup Id="CG_Languages" Directory="LANGDIR">
           <Component Id="C_Lang_1027">
             <File Name="1027.json" Source="$(var.PublishDirectory)\lang\1027.json" />
@@ -224,6 +258,7 @@
                  Level="1">
 
             <ComponentRef Id="C_PicoTorrent" />
+            <ComponentGroupRef Id="CG_Libraries" />
 
             <Feature Id="F_Lang"
                      Title="Language files"

--- a/installer/PicoTorrentBundle.wxs
+++ b/installer/PicoTorrentBundle.wxs
@@ -3,9 +3,25 @@
 <?if $(var.Platform) = "x64" ?>
     <?define InstallFolder = "[ProgramFiles64Folder]PicoTorrent" ?>
     <?define UpgradeCode = "58903cac-fb00-4335-8149-0e1177cc8cba" ?>
+
+    <?define FindVCRedistKey = "Software\Wow6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x64" ?>
+    <?define VCRedistDescription = "Microsoft Visual C++ 2015 Redistributable (x64) - 14.0.23506" ?>
+    <?define VCRedistHash = "9a19a51d1f40cd5cd5ecb6e4e4f978f18da8212a" ?>
+    <?define VCRedistName = "VC_redist.x64.exe" ?>
+    <?define VCRedistSize = "14773216" ?>
+    <?define VCRedistUrl = "https://download.microsoft.com/download/C/E/5/CE514EAE-78A8-4381-86E8-29108D78DBD4/VC_redist.x64.exe" ?>
+    <?define VCRedistVersion = "14.0.23506.0" ?>
 <?else ?>
     <?define InstallFolder = "[ProgramFilesFolder]PicoTorrent" ?>
     <?define UpgradeCode = "08b52a3a-63eb-47c0-8a75-1df052a99042" ?>
+
+    <?define FindVCRedistKey = "Software\Microsoft\VisualStudio\14.0\VC\Runtimes\x86" ?>
+    <?define VCRedistDescription = "Microsoft Visual C++ 2015 Redistributable (x86) - 14.0.23506" ?>
+    <?define VCRedistHash = "17b381d3adb22f00e4ab47cbd91ce0a5b1ccbc70" ?>
+    <?define VCRedistName = "VC_redist.x86.exe" ?>
+    <?define VCRedistSize = "13977352" ?>
+    <?define VCRedistUrl = "https://download.microsoft.com/download/C/E/5/CE514EAE-78A8-4381-86E8-29108D78DBD4/VC_redist.x86.exe" ?>
+    <?define VCRedistVersion = "14.0.23506.0" ?>
 <?endif ?>
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
@@ -19,6 +35,14 @@
             UpgradeCode="$(var.UpgradeCode)"
             Version="$(var.Version)">
 
+        <!-- Search for the C++ redistributable -->
+        <util:RegistrySearch Id="FindVCRedist"
+                             Root="HKLM"
+                             Key="$(var.FindVCRedistKey)"
+                             Value="installed"
+                             Variable="VCRedistExists"
+                             Result="exists" />
+
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense">
             <bal:WixStandardBootstrapperApplication LicenseFile="LICENSE.rtf"
                                                     LogoFile="res/app.png" />
@@ -28,6 +52,24 @@
         <Variable Name="LaunchTarget" Value="[InstallFolder]\PicoTorrent.exe"/>
 
         <Chain>
+            <ExePackage Name="$(var.VCRedistName)"
+                        Compressed="no"
+                        DetectCondition="VCRedistExists"
+                        DownloadUrl="$(var.VCRedistUrl)"
+                        InstallCommand="/quiet"
+                        PerMachine="yes"
+                        Permanent="yes"
+                        Vital="yes">
+
+                <RemotePayload Description="$(var.VCRedistDescription)"
+                               Hash="$(var.VCRedistHash)"
+                               ProductName="$(var.VCRedistDescription)"
+                               Size="$(var.VCRedistSize)"
+                               Version="$(var.VCRedistVersion)" />
+            </ExePackage>
+
+            <RollbackBoundary />
+
             <MsiPackage Id="PicoTorrentPackage"
                         Compressed="yes"
                         SourceFile="$(var.PicoTorrentInstaller)">

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Cake" version="0.8.0" />
   <package id="Cake.CMake" version="0.0.2" />
-  <package id="PicoTorrent.Libs" version="0.8.0" />
+  <package id="PicoTorrent.Libs" version="0.10.0" />
   <package id="WiX.Toolset" version="3.9.1208" />
 </packages>


### PR DESCRIPTION
PicoTorrent is currently statically linked for Boost, OpenSSL and Rasterbar-libtorrent, as well as the VC runtime. This has been great but caused problems when introducing the WebSocket API.

This PR links everything dynamically (as `.dll` files) instead. A few more files to track, but worth it.

Closes #248 