### PR TITLE
Refactor configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,13 @@ set(PICOTORRENT_SOURCES
     src/client/application
     src/client/application_initializer
     src/client/command_line
+
+    # Configuration w/ parts
     src/client/configuration
+    src/client/configuration_part
+    src/client/configuration_session_part
+    src/client/configuration_websocket_part
+
     src/client/environment
     src/client/message_loop
     src/client/string_operations

--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -1,0 +1,70 @@
+Configuration
+=============
+
+PicoTorrent is stores its configuration in a JSON file and depending on if
+PicoTorrent was installed or not the file will reside at different locations.
+
+* If installed, the file can be found at
+  :file:`%APPDATA%/PicoTorrent/PicoTorrent.json`.
+* If not installed, the file will be placed next to :file:`PicoTorrent.exe`.
+
+
+Advanced settings
+-----------------
+
+The following is an annotated example file with all settings that are not
+available for configuration from the GUI (ie. you need to edit the JSON file
+directly).
+
+.. code-block:: javascript
+   :linenos:
+
+   {
+     // If a user chooses to ignore an update, that version number is stored
+     // in this field.
+     "ignored_update": "",
+
+     // The API URL where PicoTorrent will check for the latest release.
+     "update_url": "https://api.github.com/repos/picotorrent/picotorrent/releases/latest",
+
+     "session": {
+        // The max number of simultaneous torrents to allow in 'checking'.
+        "active_checking": 1,
+
+        // The max number of torrents to announce to the DHT.
+        "active_dht_limit": 88,
+
+        // The max number of active downloads.
+        "active_downloads": 3,
+
+        // The max number of active torrents across states.
+        "active_limit": 15,
+
+        // The max number of torrents that are allowed to be *loaded* at
+        // any given time. PicoTorrent will at times load and unload inactive
+        // torrents from memory to conserve memory usage.
+        "active_loaded_limit": 100,
+
+        // The max number of torrents to announce to the local network over the
+        // local service discovery protocol.
+        "active_lsd_limit": 60,
+
+        // The max number of active seeds.
+        "active_seeds": 5,
+
+        // The max number of torrents to announce to their trackers.
+        "active_tracker_limit": 1600
+     },
+
+     "websocket": {
+        // The access token to use when connecting to the WebSocket API.
+        "access_token": "random characters",
+
+        // The full path to an SSL certificate which secures the WebSocket API.
+        "certificate_file": "PicoTorrent_generated.pem",
+
+        // The password for the SSL certificate (or empty string if no password).
+        "certificate_password": "secret"
+     }
+   }
+

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -14,4 +14,5 @@ Rasterbar-libtorrent and the raw Win32 API.
 .. toctree::
    :maxdepth: 2
 
+   configuration
    websocket-api/index

--- a/include/picotorrent/client/configuration.hpp
+++ b/include/picotorrent/client/configuration.hpp
@@ -61,12 +61,78 @@ namespace client
             uint32_t show;
         };
 
+        class part
+        {
+            friend class configuration;
+
+        protected:
+            part(const std::shared_ptr<picojson::object> &cfg);
+
+            bool get_part_key_or_default(const char *part, const char* key, bool default_value);
+            int get_part_key_or_default(const char *part, const char* key, int default_value);
+            std::string get_part_key_or_default(const char *part, const char* key, const std::string &default_value);
+
+            void set_part_key(const char *part, const char* key, bool value);
+            void set_part_key(const char *part, const char* key, int value);
+            void set_part_key(const char *part, const char* key, const std::string &value);
+
+        private:
+            std::shared_ptr<picojson::object> cfg_;
+        };
+
+        struct session_part : public part
+        {
+            friend class configuration;
+
+            int active_checking();
+            int active_dht_limit();
+            int active_downloads();
+            int active_limit();
+            int active_loaded_limit();
+            int active_lsd_limit();
+            int active_seeds();
+            int active_tracker_limit();
+
+            int download_rate_limit();
+            void download_rate_limit(int limit);
+
+            int stop_tracker_timeout();
+
+            int upload_rate_limit();
+            void upload_rate_limit(int limit);
+
+        protected:
+            using part::part;
+        };
+
+        struct websocket_part : public part
+        {
+            friend class configuration;
+
+            std::string access_token();
+            void access_token(const std::string &token);
+
+            std::string certificate_file();
+            std::string certificate_password();
+            std::string cipher_list();
+
+            bool enabled();
+            void enabled(bool enable);
+
+            int listen_port();
+            void listen_port(int port);
+
+        protected:
+            using part::part;
+        };
+
         configuration();
         ~configuration();
 
         static configuration &instance();
 
-        int alert_queue_size();
+        std::shared_ptr<session_part> session();
+        std::shared_ptr<websocket_part> websocket();
 
         close_action_t close_action();
         void set_close_action(close_action_t action);
@@ -78,9 +144,6 @@ namespace client
         
         std::string default_save_path();
         void set_default_save_path(const std::string &path);
-
-        int download_rate_limit();
-        void set_download_rate_limit(int dl_rate);
 
         std::string ignored_update();
         void set_ignored_update(const std::string &version);
@@ -126,22 +189,7 @@ namespace client
         start_position_t start_position();
         void set_start_position(start_position_t pos);
 
-        int stop_tracker_timeout();
         std::string update_url();
-
-        int upload_rate_limit();
-        void set_upload_rate_limit(int ul_rate);
-
-        std::string websocket_access_token();
-        void set_websocket_access_token(const std::string &token);
-
-        std::string websocket_certificate_file();
-        std::string websocket_certificate_password();
-        std::string websocket_cipher_list();
-        bool websocket_enabled();
-        void set_websocket_enabled(bool value);
-        int websocket_listen_port();
-        void set_websocket_listen_port(int port);
 
         std::shared_ptr<placement> window_placement(const std::string &name);
         void set_window_placement(const std::string &name, const placement &wnd);
@@ -162,7 +210,7 @@ namespace client
         void load();
         void save();
 
-        std::unique_ptr<picojson::object> value_;
+        std::shared_ptr<picojson::object> value_;
     };
 }
 }

--- a/include/picotorrent/core/session_configuration.hpp
+++ b/include/picotorrent/core/session_configuration.hpp
@@ -31,6 +31,16 @@ namespace core
         {
         }
 
+        // Limits
+        int active_checking;
+        int active_dht_limit;
+        int active_downloads;
+        int active_limit;
+        int active_loaded_limit;
+        int active_lsd_limit;
+        int active_seeds;
+        int active_tracker_limit;
+
         int alert_queue_size;
         std::string default_save_path;
         int download_rate_limit;

--- a/src/client/application.cpp
+++ b/src/client/application.cpp
@@ -183,7 +183,7 @@ int application::run(const std::wstring &args)
         ShowWindow(main_window_->handle(), pos);
     }
 
-    if (cfg.websocket_enabled())
+    if (cfg.websocket()->enabled())
     {
         ws_server_->start();
     }

--- a/src/client/application_initializer.cpp
+++ b/src/client/application_initializer.cpp
@@ -36,20 +36,20 @@ void application_initializer::create_application_paths()
 void application_initializer::generate_websocket_access_token()
 {
     configuration &cfg = configuration::instance();
-    std::string access_token = cfg.websocket_access_token();
+    std::string access_token = cfg.websocket()->access_token();
 
     if (access_token.empty())
     {
         random_string_generator rsg;
         std::string random_token = rsg.generate(DEFAULT_ACCESS_TOKEN_SIZE);
-        cfg.set_websocket_access_token(random_token);
+        cfg.websocket()->access_token(random_token);
     }
 }
 
 void application_initializer::generate_websocket_certificate()
 {
     configuration &cfg = configuration::instance();
-    std::string certificate_file = cfg.websocket_certificate_file();
+    std::string certificate_file = cfg.websocket()->certificate_file();
 
     if (!pal::file_exists(certificate_file))
     {

--- a/src/client/configuration_part.cpp
+++ b/src/client/configuration_part.cpp
@@ -1,0 +1,73 @@
+#include <picotorrent/client/configuration.hpp>
+
+#include <memory>
+#include <string>
+
+#include <picojson.hpp>
+
+namespace pj = picojson;
+using picotorrent::client::configuration;
+
+configuration::part::part(const std::shared_ptr<pj::object> &cfg)
+    : cfg_(cfg)
+{
+}
+
+std::shared_ptr<pj::value> find_value(const std::shared_ptr<pj::object> &cfg, const char *part, const char* key)
+{
+    if (cfg->find(part) == cfg->end()) { return nullptr; }
+
+    pj::value v = cfg->at(part);
+    if (!v.is<pj::object>()) { return nullptr; }
+
+    pj::object o = v.get<pj::object>();
+    if (o.find(key) == o.end()) { return nullptr; }
+
+    return std::make_shared<pj::value>(o.at(key));
+}
+
+void set_value(const std::shared_ptr<pj::object> &cfg, const char *part, const char* key, const pj::value &val)
+{
+    if (cfg->find(part) == cfg->end())
+    {
+        pj::object temp;
+        cfg->insert({ part, pj::value(temp) });
+    }
+
+    pj::object o = cfg->at(part).get<pj::object>();
+    o[key] = val;
+    (*cfg.get())[part] = pj::value(o);
+}
+
+bool configuration::part::get_part_key_or_default(const char *part, const char* key, bool default_value)
+{
+    auto v = find_value(cfg_, part, key);
+    return v == nullptr ? default_value : v->get<bool>();
+}
+
+int configuration::part::get_part_key_or_default(const char *part, const char* key, int default_value)
+{
+    auto v = find_value(cfg_, part, key);
+    return v == nullptr ? default_value : (int)v->get<int64_t>();
+}
+
+std::string configuration::part::get_part_key_or_default(const char *part, const char* key, const std::string &default_value)
+{
+    auto v = find_value(cfg_, part, key);
+    return v == nullptr ? default_value : v->get<std::string>();
+}
+
+void configuration::part::set_part_key(const char *part, const char* key, bool value)
+{
+    set_value(cfg_, part, key, pj::value(value));
+}
+
+void configuration::part::set_part_key(const char *part, const char* key, int value)
+{
+    set_value(cfg_, part, key, pj::value((int64_t)value));
+}
+
+void configuration::part::set_part_key(const char *part, const char* key, const std::string &value)
+{
+    set_value(cfg_, part, key, pj::value(value));
+}

--- a/src/client/configuration_session_part.cpp
+++ b/src/client/configuration_session_part.cpp
@@ -1,0 +1,91 @@
+#include <picotorrent/client/configuration.hpp>
+
+#include <memory>
+
+#include <picojson.hpp>
+
+namespace pj = picojson;
+using picotorrent::client::configuration;
+
+int configuration::session_part::active_checking()
+{
+    return get_part_key_or_default("session", "active_checking", 1);
+}
+
+int configuration::session_part::active_dht_limit()
+{
+    return get_part_key_or_default("session", "active_dht_limit", 88);
+}
+
+int configuration::session_part::active_downloads()
+{
+    return get_part_key_or_default("session", "active_downloads", 3);
+}
+
+int configuration::session_part::active_limit()
+{
+    return get_part_key_or_default("session", "active_limit", 15);
+}
+
+int configuration::session_part::active_loaded_limit()
+{
+    return get_part_key_or_default("session", "active_loaded_limit", 100);
+}
+
+int configuration::session_part::active_lsd_limit()
+{
+    return get_part_key_or_default("session", "active_lsd_limit", 60);
+}
+
+int configuration::session_part::active_seeds()
+{
+    return get_part_key_or_default("session", "active_seeds", 5);
+}
+
+int configuration::session_part::active_tracker_limit()
+{
+    return get_part_key_or_default("session", "active_tracker_limit", 1600);
+}
+
+int configuration::session_part::download_rate_limit()
+{
+    const char* key = __func__;
+
+    // Check old configuration and do some cleanups if found.
+    if (cfg_->find(key) != cfg_->end())
+    {
+        download_rate_limit((int)cfg_->at(key).get<int64_t>());
+        cfg_->erase(key);
+    }
+
+    return get_part_key_or_default("session", key, 0);
+}
+
+void configuration::session_part::download_rate_limit(int limit)
+{
+    set_part_key("session", "download_rate_limit", limit);
+}
+
+int configuration::session_part::stop_tracker_timeout()
+{
+    return get_part_key_or_default("session", "stop_tracker_timeout", 1);
+}
+
+int configuration::session_part::upload_rate_limit()
+{
+    const char* key = __func__;
+
+    // Check old configuration and do some cleanups if found.
+    if (cfg_->find(key) != cfg_->end())
+    {
+        upload_rate_limit((int)cfg_->at(key).get<int64_t>());
+        cfg_->erase(key);
+    }
+
+    return get_part_key_or_default("session", key, 0);
+}
+
+void configuration::session_part::upload_rate_limit(int limit)
+{
+    set_part_key("session", "upload_rate_limit", limit);
+}

--- a/src/client/configuration_websocket_part.cpp
+++ b/src/client/configuration_websocket_part.cpp
@@ -1,0 +1,62 @@
+#include <picotorrent/client/configuration.hpp>
+
+#include <picotorrent/client/environment.hpp>
+#include <picotorrent/core/pal.hpp>
+
+#include <memory>
+
+#include <picojson.hpp>
+
+namespace pj = picojson;
+using picotorrent::client::configuration;
+using picotorrent::client::environment;
+using picotorrent::core::pal;
+
+std::string configuration::websocket_part::access_token()
+{
+    return get_part_key_or_default("websocket", "access_token", std::string());
+}
+
+void configuration::websocket_part::access_token(const std::string &token)
+{
+    set_part_key("websocket", "access_token", token);
+}
+
+std::string configuration::websocket_part::certificate_file()
+{
+    std::string data_path = environment::get_data_path();
+    std::string default_file = pal::combine_paths(data_path, "PicoTorrent_generated.pem");
+
+    return get_part_key_or_default("websocket", "certificate_file", default_file);
+}
+
+std::string configuration::websocket_part::certificate_password()
+{
+    return get_part_key_or_default("websocket", "certificate_password", std::string());
+}
+
+std::string configuration::websocket_part::cipher_list()
+{
+    std::string default_ciphers = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK";
+    return get_part_key_or_default("websocket", "certificate_password", default_ciphers);
+}
+
+bool configuration::websocket_part::enabled()
+{
+    return get_part_key_or_default("websocket", "enabled", false);
+}
+
+void configuration::websocket_part::enabled(bool enable)
+{
+    set_part_key("websocket", "enabled", enable);
+}
+
+int configuration::websocket_part::listen_port()
+{
+    return get_part_key_or_default("websocket", "listen_port", 7676);
+}
+
+void configuration::websocket_part::listen_port(int port)
+{
+    set_part_key("websocket", "listen_port", port);
+}

--- a/src/client/controllers/view_preferences_controller.cpp
+++ b/src/client/controllers/view_preferences_controller.cpp
@@ -120,8 +120,8 @@ void view_preferences_controller::on_downloads_apply()
     int ul_rate = dl_page_->upload_rate();
     if (ul_rate > 0) { ul_rate *= 1024; }
 
-    cfg.set_download_rate_limit(dl_rate);
-    cfg.set_upload_rate_limit(ul_rate);
+    cfg.session()->download_rate_limit(dl_rate);
+    cfg.session()->upload_rate_limit(ul_rate);
 }
 
 bool view_preferences_controller::on_downloads_validate()
@@ -198,8 +198,8 @@ void view_preferences_controller::on_downloads_init()
     dl_page_->set_downloads_path(cfg.default_save_path());
     dl_page_->set_prompt_for_save_path(cfg.prompt_for_save_path());
 
-    int dl_rate = cfg.download_rate_limit();
-    int ul_rate = cfg.upload_rate_limit();
+    int dl_rate = cfg.session()->download_rate_limit();
+    int ul_rate = cfg.session()->upload_rate_limit();
 
     if (dl_rate < 0) { dl_rate = 0; }
     if (dl_rate > 0) { dl_rate /= 1024; }
@@ -301,17 +301,17 @@ void view_preferences_controller::on_remote_apply()
 {
     configuration &cfg = configuration::instance();
 
-    cfg.set_websocket_enabled(remote_page_->enable_websocket_api());
+    cfg.websocket()->enabled(remote_page_->enable_websocket_api());
     if (remote_page_->websocket_port() > 0)
     {
-        cfg.set_websocket_listen_port(remote_page_->websocket_port());
+        cfg.websocket()->listen_port(remote_page_->websocket_port());
     }
 
-    if (cfg.websocket_enabled())
+    if (cfg.websocket()->enabled())
     {
         ws_->start();
     }
-    else if (!cfg.websocket_enabled())
+    else if (!cfg.websocket()->enabled())
     {
         ws_->stop();
     }
@@ -321,11 +321,11 @@ void view_preferences_controller::on_remote_init()
 {
     configuration &cfg = configuration::instance();
 
-    remote_page_->set_enable_websocket_api(cfg.websocket_enabled());
-    remote_page_->set_websocket_access_token(cfg.websocket_access_token());
-    remote_page_->set_websocket_port(cfg.websocket_listen_port());
+    remote_page_->set_enable_websocket_api(cfg.websocket()->enabled());
+    remote_page_->set_websocket_access_token(cfg.websocket()->access_token());
+    remote_page_->set_websocket_port(cfg.websocket()->listen_port());
 
-    std::string cert_file = cfg.websocket_certificate_file();
+    std::string cert_file = cfg.websocket()->certificate_file();
     std::string pub_key = security::certificate_manager::extract_public_key(cert_file);
 
     remote_page_->set_certificate_public_key(pub_key);

--- a/src/client/ws/websocket_server.cpp
+++ b/src/client/ws/websocket_server.cpp
@@ -43,8 +43,8 @@ websocket_server::websocket_server(const std::shared_ptr<session> &session)
     srv_->set_validate_handler(std::bind(&websocket_server::on_validate, this, std::placeholders::_1));
 
     configuration &cfg = configuration::instance();
-    certificate_file_ = cfg.websocket_certificate_file();
-    configured_token_ = cfg.websocket_access_token();
+    certificate_file_ = cfg.websocket()->certificate_file();
+    configured_token_ = cfg.websocket()->access_token();
 }
 
 websocket_server::~websocket_server()
@@ -79,7 +79,7 @@ void websocket_server::stop()
 
 std::string websocket_server::get_certificate_password()
 {
-    return configuration::instance().websocket_certificate_password();
+    return configuration::instance().websocket()->certificate_password();
 }
 
 void websocket_server::on_close(websocketpp::connection_hdl hdl)
@@ -134,7 +134,7 @@ context_ptr websocket_server::on_tls_init(websocketpp::connection_hdl hdl)
 
     auto dh = dh_params::get();
     SSL_CTX_set_tmp_dh(ctx->native_handle(), dh.get());
-    SSL_CTX_set_cipher_list(ctx->native_handle(), cfg.websocket_cipher_list().c_str());
+    SSL_CTX_set_cipher_list(ctx->native_handle(), cfg.websocket()->cipher_list().c_str());
 
     return ctx;
 }
@@ -202,7 +202,7 @@ void websocket_server::run()
 {
     configuration &cfg = configuration::instance();
 
-    srv_->listen(cfg.websocket_listen_port());
+    srv_->listen(cfg.websocket()->listen_port());
     srv_->start_accept();
     srv_->run();
 }

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -257,6 +257,16 @@ std::shared_ptr<lt::settings_pack> session::get_session_settings()
     settings->set_int(lt::settings_pack::download_rate_limit, config_->download_rate_limit);
     settings->set_int(lt::settings_pack::upload_rate_limit, config_->upload_rate_limit);
 
+    // Limits
+    settings->set_int(lt::settings_pack::active_checking, config_->active_checking);
+    settings->set_int(lt::settings_pack::active_dht_limit, config_->active_dht_limit);
+    settings->set_int(lt::settings_pack::active_downloads, config_->active_downloads);
+    settings->set_int(lt::settings_pack::active_limit, config_->active_limit);
+    settings->set_int(lt::settings_pack::active_loaded_limit, config_->active_loaded_limit);
+    settings->set_int(lt::settings_pack::active_lsd_limit, config_->active_lsd_limit);
+    settings->set_int(lt::settings_pack::active_seeds, config_->active_seeds);
+    settings->set_int(lt::settings_pack::active_tracker_limit, config_->active_tracker_limit);
+
     // Calculate user agent
     std::stringstream user_agent;
     user_agent << "PicoTorrent/" << version_info::current_version();


### PR DESCRIPTION
We have up until now used a single class `configuration` for all configuration for PicoTorrent.

This PR refactors this and moves relevant settings to their own parts - i.e session related settings will be moved to a class managing just that. It also adds a few session settings related to limits. They are currently only changeable by editing the JSON file, and the documentation has been updated to show how.

Closes #226 