### PR TITLE
Handle invalid torrent files.

### DIFF
--- a/include/picotorrent/core/torrent_info.hpp
+++ b/include/picotorrent/core/torrent_info.hpp
@@ -28,7 +28,7 @@ namespace core
         DLL_EXPORT torrent_info(const libtorrent::torrent_info &info);
         DLL_EXPORT ~torrent_info();
 
-        DLL_EXPORT static torrent_info_ptr try_load(const std::string &path);
+        DLL_EXPORT static torrent_info_ptr try_load(const std::string &path, std::string &err);
 
         DLL_EXPORT std::string file_path(int index) const;
         DLL_EXPORT int64_t file_size(int index) const;

--- a/lang/1033.json
+++ b/lang/1033.json
@@ -171,6 +171,7 @@
         "full": "Full",
         "show_qr_code": "<a href=\"#\">Show QR code</a>",
         "invalid_download_rate_limit": "Invalid download rate limit.",
-        "invalid_upload_rate_limit": "Invalid upload rate limit."
+        "invalid_upload_rate_limit": "Invalid upload rate limit.",
+        "error_when_loading_torrent": "Error when loading torrent"
     }
 }

--- a/src/client/controllers/add_torrent_controller.cpp
+++ b/src/client/controllers/add_torrent_controller.cpp
@@ -125,8 +125,21 @@ void add_torrent_controller::add_files(const std::vector<std::string> &paths)
 
     for (const std::string &p : paths)
     {
-        auto ti = core::torrent_info::try_load(p);
-        if (!ti) { continue; }
+        std::string err;
+        auto ti = core::torrent_info::try_load(p, err);
+
+        if (!ti)
+        {
+            ui::task_dialog dlg;
+            dlg.set_common_buttons(TDCBF_OK_BUTTON);
+            dlg.set_content(err);
+            dlg.set_main_icon(TD_ERROR_ICON);
+            dlg.set_main_instruction(TR("error_when_loading_torrent"));
+            dlg.set_title("PicoTorrent");
+            dlg.show();
+
+            continue;
+        }
 
         auto r = std::make_shared<core::add_request>();
         r->set_torrent_info(ti);

--- a/src/core/torrent_info.cpp
+++ b/src/core/torrent_info.cpp
@@ -28,7 +28,7 @@ torrent_info::~torrent_info()
 {
 }
 
-std::shared_ptr<torrent_info> torrent_info::try_load(const std::string &path)
+std::shared_ptr<torrent_info> torrent_info::try_load(const std::string &path, std::string &err)
 {
     if (!pal::file_exists(path))
     {
@@ -40,8 +40,18 @@ std::shared_ptr<torrent_info> torrent_info::try_load(const std::string &path)
 
     std::stringstream ss;
     ss << file_stream.rdbuf();
+    std::string buf = ss.str();
 
-    return std::make_shared<torrent_info>(ss.str());
+    lt::error_code ec;
+    lt::torrent_info ti(&buf[0], (int)buf.size(), ec);
+
+    if (ec)
+    {
+        err = ec.message();
+        return nullptr;
+    }
+
+    return std::make_shared<core::torrent_info>(ti);
 }
 
 std::string torrent_info::file_path(int index) const


### PR DESCRIPTION
When opening an invalid torrent file (from Explorer, not the Add torrent dialog) PicoTorrent crashed.
Instead, show a dialog describing the error.

Closes #270 