### PR TITLE
[WIP] .NET plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,13 @@ set(PICOTORRENTCLIENT_SOURCES
     src/client/pico.rc
 )
 
+set(PICOTORRENTNETFX_SOURCES
+    src/netfx/managed_bridge
+    src/netfx/clr_plugin
+    src/netfx/clr/plugin_host
+    src/netfx/clr/session
+)
+
 set(PICOTORRENTSERVER_SOURCES
     src/server/application
     src/server/hosting/console_host
@@ -253,6 +260,11 @@ target_link_libraries(
 )
 
 if(WIN32)
+    # This makes the C++/CLI project compile.
+    if(CMAKE_CXX_FLAGS_DEBUG MATCHES "/RTC1")
+        string(REPLACE "/RTC1" " " CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    endif()
+
     target_link_libraries(
         PicoTorrentCore
 
@@ -284,9 +296,27 @@ if(WIN32)
     )
 
     add_library(
+        PicoTorrentNetFx
+        SHARED
+        ${PICOTORRENTNETFX_SOURCES}
+    )
+
+    add_library(
         PicoTorrentServer
         SHARED
         ${PICOTORRENTSERVER_SOURCES}
+    )
+
+    set_target_properties(
+        PicoTorrentNetFx
+        PROPERTIES
+        VS_DOTNET_REFERENCES "System;System.Windows.Forms")
+
+    target_compile_options(
+        PicoTorrentNetFx
+        PUBLIC
+        /clr
+        /EHa
     )
 
     target_link_libraries(
@@ -309,6 +339,11 @@ if(WIN32)
 
     target_link_libraries(
         PicoTorrentCommon
+        PicoTorrentCore
+    )
+
+    target_link_libraries(
+        PicoTorrentNetFx
         PicoTorrentCore
     )
 

--- a/include/picotorrent/netfx/clr/plugin_host.hpp
+++ b/include/picotorrent/netfx/clr/plugin_host.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace PicoTorrent
+{
+namespace Core
+{
+    ref class Session;
+}
+
+    ref class PluginHost
+    {
+    public:
+        PluginHost(Core::Session^);
+
+        void Load();
+        void Unload();
+
+    private:
+        Core::Session^ _session;
+    };
+}

--- a/include/picotorrent/netfx/clr/session.hpp
+++ b/include/picotorrent/netfx/clr/session.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace picotorrent { namespace core { class session; } }
+
+namespace PicoTorrent
+{
+namespace Core
+{
+    ref class Session
+    {
+    public:
+        Session(picotorrent::core::session *s);
+
+    private:
+        picotorrent::core::session* s_;
+    };
+}
+}

--- a/include/picotorrent/netfx/clr_plugin.hpp
+++ b/include/picotorrent/netfx/clr_plugin.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#pragma unmanaged
+
+#include <picotorrent/export.hpp>
+#include <picotorrent/plugin.hpp>
+
+namespace picotorrent
+{
+namespace core
+{
+    class session;
+}
+namespace netfx
+{
+    class managed_bridge;
+
+    class clr_plugin : public plugin
+    {
+    public:
+        clr_plugin(core::session*);
+        ~clr_plugin();
+
+        void load();
+        void unload();
+
+    private:
+        managed_bridge* bridge_;
+    };
+}
+}
+
+extern "C"
+{
+    DLL_EXPORT picotorrent::plugin* create_picotorrent_plugin(picotorrent::core::session* sess)
+    {
+        return new picotorrent::netfx::clr_plugin(sess);
+    }
+}

--- a/include/picotorrent/netfx/managed_bridge.hpp
+++ b/include/picotorrent/netfx/managed_bridge.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#pragma managed
+
+#include <vcclr.h>
+
+namespace PicoTorrent
+{
+    ref class PluginHost;
+}
+
+namespace picotorrent
+{
+namespace core
+{
+    class session;
+}
+namespace netfx
+{
+    class managed_bridge
+    {
+    public:
+        managed_bridge(core::session*);
+
+        void load();
+        void unload();
+
+    private:
+        gcroot<PicoTorrent::PluginHost^> host_;
+    };
+}
+}

--- a/include/picotorrent/plugin.hpp
+++ b/include/picotorrent/plugin.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace picotorrent
+{
+    class plugin
+    {
+    public:
+        virtual void load() = 0;
+        virtual void unload() = 0;
+    };
+}

--- a/src/client/normal_executor.cpp
+++ b/src/client/normal_executor.cpp
@@ -2,6 +2,7 @@
 
 #include <functional>
 
+#include <picotorrent/plugin.hpp>
 #include <picotorrent/client/message_loop.hpp>
 #include <picotorrent/client/controllers/add_magnet_link_controller.hpp>
 #include <picotorrent/client/controllers/add_torrent_controller.hpp>
@@ -22,6 +23,7 @@
 #include <picotorrent/core/torrent.hpp>
 
 namespace controllers = picotorrent::client::controllers;
+using picotorrent::plugin;
 using picotorrent::client::message_loop;
 using picotorrent::client::normal_executor;
 using picotorrent::common::command_line;
@@ -106,6 +108,15 @@ int normal_executor::run(const command_line &cmd)
     {
         updater_->execute();
     }
+
+    HMODULE hMod = LoadLibrary(L"PicoTorrentPlugin.dll");
+    FARPROC proc = GetProcAddress(hMod, "create_plugin_host");
+
+    typedef plugin*(*CREATE_PLUGIN_FUNC)(session*);
+    CREATE_PLUGIN_FUNC cpf = (CREATE_PLUGIN_FUNC)proc;
+
+    plugin* p = cpf(session_.get());
+    p->load();
 
     return message_loop::run(main_window_->handle(), accelerators_);
 }

--- a/src/netfx/clr/plugin_host.cpp
+++ b/src/netfx/clr/plugin_host.cpp
@@ -1,0 +1,20 @@
+#include <picotorrent/netfx/clr/plugin_host.hpp>
+
+#include <picotorrent/netfx/clr/session.hpp>
+
+using PicoTorrent::PluginHost;
+using PicoTorrent::Core::Session;
+
+PluginHost::PluginHost(Session^ session)
+{
+    _session = session;
+}
+
+void PluginHost::Load()
+{
+    System::Windows::Forms::MessageBox::Show("Hello!");
+}
+
+void PluginHost::Unload()
+{
+}

--- a/src/netfx/clr/session.cpp
+++ b/src/netfx/clr/session.cpp
@@ -1,0 +1,11 @@
+#include <picotorrent/netfx/clr/session.hpp>
+
+#include <picotorrent/core/session.hpp>
+
+using picotorrent::core::session;
+using PicoTorrent::Core::Session;
+
+Session::Session(session* sess)
+    : s_(sess)
+{
+}

--- a/src/netfx/clr_plugin.cpp
+++ b/src/netfx/clr_plugin.cpp
@@ -1,0 +1,28 @@
+#include <picotorrent/netfx/clr_plugin.hpp>
+
+#include <picotorrent/core/session.hpp>
+#include <picotorrent/netfx/managed_bridge.hpp>
+
+using picotorrent::core::session;
+using picotorrent::netfx::managed_bridge;
+using picotorrent::netfx::clr_plugin;
+
+clr_plugin::clr_plugin(session* sess)
+{
+    bridge_ = new managed_bridge(sess);
+}
+
+clr_plugin::~clr_plugin()
+{
+    delete bridge_;
+}
+
+void clr_plugin::load()
+{
+    bridge_->load();
+}
+
+void clr_plugin::unload()
+{
+    bridge_->unload();
+}

--- a/src/netfx/managed_bridge.cpp
+++ b/src/netfx/managed_bridge.cpp
@@ -1,0 +1,24 @@
+#include <picotorrent/netfx/managed_bridge.hpp>
+
+#include <picotorrent/core/session.hpp>
+#include <picotorrent/netfx/clr/plugin_host.hpp>
+#include <picotorrent/netfx/clr/session.hpp>
+
+using picotorrent::core::session;
+using picotorrent::netfx::managed_bridge;
+
+managed_bridge::managed_bridge(session *sess)
+{
+    host_ = gcnew PicoTorrent::PluginHost(
+        gcnew PicoTorrent::Core::Session(sess));
+}
+
+void managed_bridge::load()
+{
+    host_->Load();
+}
+
+void managed_bridge::unload()
+{
+    host_->Unload();
+}


### PR DESCRIPTION
This PR adds support for plugins written in .NET (C#, VB.NET, etc). PicoTorrent will still be a native application, but a few extension points will be exposed where plugin authors can interact with PicoTorrent.

TODO
- [x] Create a simple .NET framework plugin host.
- [ ] Add support for user interface interaction from plugins.
- [ ] Load .NET assemblies from configured directory.
- [ ] Move update checking to a plugin.
- [ ] Add CMake option to disable plugin support.