### PR TITLE
Update Rasterbar-libtorrent, Boost and OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,11 +166,7 @@ target_link_libraries(
 
     ${PICO_LIBS}
 
-    # Boost Random
-    debug boost_random-vc140-mt-gd-1_60
-    optimized boost_random-vc140-mt-1_60
-
     # Boost System
-    debug boost_system-vc140-mt-gd-1_60
-    optimized boost_system-vc140-mt-1_60
+    debug boost_system-vc140-mt-gd-1_61
+    optimized boost_system-vc140-mt-1_61
 )

--- a/build.cake
+++ b/build.cake
@@ -32,8 +32,7 @@ var SymbolsPackage     = string.Format("PicoTorrent-{0}-{1}.symbols.zip", Versio
 bool IsDebug() { return configuration.Equals("Debug"); }
 
 // Boost naming ickiness
-var BoostRandom = IsDebug() ? "boost_random-vc140-mt-gd-1_60.dll" : "boost_random-vc140-mt-1_60.dll";
-var BoostSystem = IsDebug() ? "boost_system-vc140-mt-gd-1_60.dll" : "boost_system-vc140-mt-1_60.dll";
+var BoostSystem = IsDebug() ? "boost_system-vc140-mt-gd-1_61.dll" : "boost_system-vc140-mt-1_61.dll";
 
 public void SignTool(FilePath file)
 {
@@ -133,7 +132,6 @@ Task("Setup-Library-Files")
     var files = new FilePath[]
     {
         // 3rd party libraries
-        LibraryDirectory + File(BoostRandom),
         LibraryDirectory + File(BoostSystem),
         LibraryDirectory + File("libeay32.dll"),
         LibraryDirectory + File("ssleay32.dll"),
@@ -152,7 +150,6 @@ Task("Setup-Publish-Directory")
     {
         BuildDirectory + File("PicoTorrent.exe"),
         // 3rd party libraries
-        LibraryDirectory + File(BoostRandom),
         LibraryDirectory + File(BoostSystem),
         LibraryDirectory + File("libeay32.dll"),
         LibraryDirectory + File("ssleay32.dll"),

--- a/installer/PicoTorrent.wxs
+++ b/installer/PicoTorrent.wxs
@@ -9,11 +9,9 @@
 <?endif ?>
 
 <?if $(var.Configuration) = "Debug" ?>
-    <?define BoostRandomFile = "boost_random-vc140-mt-gd-1_60.dll" ?>
-    <?define BoostSystemFile = "boost_system-vc140-mt-gd-1_60.dll" ?>
+    <?define BoostSystemFile = "boost_system-vc140-mt-gd-1_61.dll" ?>
 <?else ?>
-    <?define BoostRandomFile = "boost_random-vc140-mt-1_60.dll" ?>
-    <?define BoostSystemFile = "boost_system-vc140-mt-1_60.dll" ?>
+    <?define BoostSystemFile = "boost_system-vc140-mt-1_61.dll" ?>
 <?endif ?>
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
@@ -183,10 +181,6 @@
         </Directory>
 
         <ComponentGroup Id="CG_Libraries" Directory="INSTALLDIR">
-          <Component Id="C_BoostRandom">
-            <File Name="$(var.BoostRandomFile)" Source="$(var.PublishDirectory)\$(var.BoostRandomFile)" />
-          </Component>
-
           <Component Id="C_BoostSystem">
             <File Name="$(var.BoostSystemFile)" Source="$(var.PublishDirectory)\$(var.BoostSystemFile)" />
           </Component>

--- a/src/CMainFrame.cpp
+++ b/src/CMainFrame.cpp
@@ -196,8 +196,9 @@ LRESULT CMainFrame::OnFindMetadata(UINT uMsg, WPARAM wParam, LPARAM lParam)
     GetTempPath(ARRAYSIZE(temp), temp);
 
     // Set a temporary save path
-    std::string ih = lt::to_hex(p.info_hash.to_string());
-    p.save_path = TS(IO::Path::Combine(temp, TWS(ih)));
+    std::stringstream hex;
+    hex << p.info_hash;
+    p.save_path = TS(IO::Path::Combine(temp, TWS(hex.str())));
 
     // Add the info hash to our list of currently requested metadata files.
     m_find_metadata.push_back({ p.info_hash });
@@ -441,7 +442,7 @@ void CMainFrame::OnDestroy()
     CMessageLoop* pLoop = _Module.GetMessageLoop();
     pLoop->RemoveMessageFilter(this);
 
-    typedef boost::function<void()> notify_func_t;
+    typedef std::function<void()> notify_func_t;
     m_session->set_alert_notify(notify_func_t());
 
     Core::SessionUnloader::Unload(m_session);
@@ -563,8 +564,9 @@ LRESULT CMainFrame::OnSessionAlert(UINT uMsg, WPARAM wParam, LPARAM lParam)
             std::wstring torrents_dir = IO::Path::Combine(Environment::GetDataPath(), TEXT("Torrents"));
             if (!IO::Directory::Exists(torrents_dir)) { IO::Directory::Create(torrents_dir); }
 
-            std::string hash = lt::to_hex(srda->handle.info_hash().to_string());
-            std::string file_name = hash + ".dat";
+            std::stringstream hex;
+            hex << srda->handle.info_hash();
+            std::string file_name = hex.str() + ".dat";
 
             std::wstring dat_file = IO::Path::Combine(torrents_dir, TWS(file_name));
             std::error_code ec;
@@ -675,7 +677,10 @@ LRESULT CMainFrame::OnSessionAlert(UINT uMsg, WPARAM wParam, LPARAM lParam)
             m_torrents.erase(tra->info_hash);
 
             // Remove the torrent and dat file from the hard drive
-            std::wstring hash = TWS(lt::to_hex(tra->info_hash.to_string()));
+            std::stringstream hex;
+            hex << tra->info_hash;
+
+            std::wstring hash = TWS(hex.str());
             std::wstring torrents_dir = IO::Path::Combine(Environment::GetDataPath(), TEXT("Torrents"));
             std::wstring torrent_file = IO::Path::Combine(torrents_dir, hash + L".torrent");
             std::wstring torrent_dat = IO::Path::Combine(torrents_dir, hash + L".dat");

--- a/src/CMainFrame.hpp
+++ b/src/CMainFrame.hpp
@@ -7,10 +7,11 @@
 #include <memory>
 #include <vector>
 
+#include <libtorrent/sha1_hash.hpp>
+
 namespace libtorrent
 {
     class session;
-    class sha1_hash;
     struct stats_metric;
     struct torrent_handle;
     struct torrent_status;

--- a/src/Controllers/AddTorrentController.cpp
+++ b/src/Controllers/AddTorrentController.cpp
@@ -64,7 +64,7 @@ void AddTorrentController::Execute(const std::vector<std::wstring>& files)
 
         auto p = std::make_shared<lt::add_torrent_params>();
         p->save_path = cfg.GetDefaultSavePath();
-        p->ti = boost::make_shared<lt::torrent_info>(node, ltec);
+        p->ti = std::make_shared<lt::torrent_info>(node, ltec);
 
         if (ltec)
         {
@@ -99,7 +99,7 @@ void AddTorrentController::Execute(const std::vector<lt::torrent_info>& torrents
     {
         auto p = std::make_shared<lt::add_torrent_params>();
         p->save_path = cfg.GetDefaultSavePath();
-        p->ti = boost::make_shared<lt::torrent_info>(ti);
+        p->ti = std::make_shared<lt::torrent_info>(ti);
 
         params.push_back(p);
     }

--- a/src/Controllers/RemoveTorrentsController.hpp
+++ b/src/Controllers/RemoveTorrentsController.hpp
@@ -6,10 +6,11 @@
 #include <memory>
 #include <vector>
 
+#include <libtorrent/sha1_hash.hpp>
+
 namespace libtorrent
 {
     class session;
-    class sha1_hash;
     struct torrent_handle;
 }
 

--- a/src/Dialogs/AddMagnetLinkDialog.cpp
+++ b/src/Dialogs/AddMagnetLinkDialog.cpp
@@ -1,6 +1,7 @@
 #include "AddMagnetLinkDialog.hpp"
 
 #include <regex>
+#include <sstream>
 
 #include <shellapi.h>
 #include <strsafe.h>

--- a/src/Dialogs/AddTorrentDialog.cpp
+++ b/src/Dialogs/AddTorrentDialog.cpp
@@ -157,7 +157,7 @@ void AddTorrentDialog::ShowTorrent(size_t torrentIndex)
     }
 
     std::shared_ptr<lt::add_torrent_params> prm = m_params.at(torrentIndex);
-    boost::shared_ptr<lt::torrent_info> ti = prm->ti;
+    std::shared_ptr<lt::torrent_info> ti = prm->ti;
 
     m_fileList->RemoveAll();
     m_savePath.SetWindowText(ToWideString(prm->save_path).c_str());

--- a/src/PropertySheets/Details/OverviewPage.cpp
+++ b/src/PropertySheets/Details/OverviewPage.cpp
@@ -1,5 +1,7 @@
 #include "OverviewPage.hpp"
 
+#include <iomanip>
+
 #include <libtorrent/sha1_hash.hpp>
 #include <libtorrent/torrent_handle.hpp>
 #include <libtorrent/torrent_status.hpp>

--- a/src/PropertySheets/Details/PeersPage.hpp
+++ b/src/PropertySheets/Details/PeersPage.hpp
@@ -3,15 +3,14 @@
 #include "../../resources.h"
 #include "../../stdafx.h"
 
-// #include <boost/asio/ip/tcp.hpp>
-
 #include <map>
 #include <memory>
 #include <string>
 
+#include <libtorrent/sha1_hash.hpp>
+
 namespace libtorrent
 {
-    class sha1_hash;
     struct torrent_handle;
 }
 

--- a/src/UI/TorrentListView.cpp
+++ b/src/UI/TorrentListView.cpp
@@ -1,5 +1,7 @@
 #include "TorrentListView.hpp"
 
+#include <iomanip>
+
 #include <libtorrent/sha1_hash.hpp>
 #include <libtorrent/torrent_info.hpp>
 #include <libtorrent/torrent_handle.hpp>
@@ -440,14 +442,14 @@ void TorrentListView::ShowContextMenu(POINT p, const std::vector<int>& sel)
     }
     case TORRENT_CONTEXT_MENU_COPY_SHA:
     {
-        std::wstringstream ss;
+        std::stringstream ss;
         std::for_each(sel.begin(), sel.end(),
             [this, &ss](int i)
         {
-            ss << L"," << TWS(lt::to_hex(m_models[i].infoHash.to_string()));
+            ss << "," << m_models[i].infoHash;
         });
 
-        Clipboard::Set(ss.str().substr(1));
+        Clipboard::Set(TWS(ss.str().substr(1)));
         break;
     }
     case TORRENT_CONTEXT_MENU_OPEN_IN_EXPLORER:

--- a/src/UIState.cpp
+++ b/src/UIState.cpp
@@ -49,7 +49,7 @@ UIState::ColumnStateMap UIState::GetListViewColumnState(const std::string& key)
         return ColumnStateMap();
     }
 
-    std::list<lt::entry> lv_entry_list = lv_entry.list();
+    std::vector<lt::entry> lv_entry_list = lv_entry.list();
     ColumnStateMap m;
 
     for (lt::entry& e : lv_entry_list)
@@ -85,7 +85,7 @@ void UIState::SetListViewColumnState(const std::string& key, const ColumnStateMa
     lt::entry& lv_entry = m_map.at("lv");
     if (lv_entry.type() != lt::entry::data_type::dictionary_t) { return; }
 
-    std::list<lt::entry> l;
+    std::vector<lt::entry> l;
 
     for (auto& p : map)
     {

--- a/src/core/SessionLoader.cpp
+++ b/src/core/SessionLoader.cpp
@@ -128,9 +128,9 @@ SessionLoader::State SessionLoader::Load()
                 continue;
             }
 
-            item.magnet_uri = node.dict_find_string_value("pT-magnetUri");
-            item.save_path = node.dict_find_string_value("pT-savePath", cfg.GetDefaultSavePath().c_str());
-            item.url = node.dict_find_string_value("pT-url");
+            item.magnet_uri = node.dict_find_string_value("pT-magnetUri").to_string();
+            item.save_path = node.dict_find_string_value("pT-savePath", cfg.GetDefaultSavePath().c_str()).to_string();
+            item.url = node.dict_find_string_value("pT-url").to_string();
 
             int64_t queuePosition = node.dict_find_int_value("pT-queuePosition", maxPosition);
             if (queuePosition < 0) { queuePosition = maxPosition; }
@@ -194,7 +194,7 @@ SessionLoader::State SessionLoader::Load()
                     continue;
                 }
 
-                params.ti = boost::make_shared<lt::torrent_info>(node);
+                params.ti = std::make_shared<lt::torrent_info>(node);
                 state.muted_hashes.push_back(params.ti->info_hash());
             }
 

--- a/src/core/SessionLoader.hpp
+++ b/src/core/SessionLoader.hpp
@@ -3,10 +3,11 @@
 #include <memory>
 #include <vector>
 
+#include <libtorrent/sha1_hash.hpp>
+
 namespace libtorrent
 {
     class session;
-    class sha1_hash;
 }
 
 namespace Core

--- a/src/core/SessionSettings.cpp
+++ b/src/core/SessionSettings.cpp
@@ -1,5 +1,7 @@
 #include "SessionSettings.hpp"
 
+#include <iomanip>
+
 #include <libtorrent/alert_types.hpp>
 #include <libtorrent/settings_pack.hpp>
 #include <semver.hpp>

--- a/src/core/SessionUnloader.cpp
+++ b/src/core/SessionUnloader.cpp
@@ -114,8 +114,9 @@ void SessionUnloader::Unload(const std::shared_ptr<lt::session>& session)
             std::vector<char> buf;
             lt::bencode(std::back_inserter(buf), *rd->resume_data);
 
-            std::string info_hash = lt::to_hex(rd->handle.info_hash().to_string());
-            std::string file_name = info_hash + ".dat";
+            std::stringstream hex;
+            hex << rd->handle.info_hash();
+            std::string file_name = hex.str() + ".dat";
             std::wstring dat_file = IO::Path::Combine(torrents_dir, TWS(file_name));
 
             std::error_code ec;

--- a/src/core/Torrent.hpp
+++ b/src/core/Torrent.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
+#include <system_error>
 
 namespace libtorrent { class torrent_info; }
 
@@ -9,6 +10,6 @@ namespace Core
     class Torrent
     {
     public:
-        static void Save(const boost::shared_ptr<const libtorrent::torrent_info>& ti, std::error_code& ec);
+        static void Save(const std::shared_ptr<const libtorrent::torrent_info>& ti, std::error_code& ec);
     };
 }

--- a/src/core/torrent.cpp
+++ b/src/core/torrent.cpp
@@ -1,5 +1,7 @@
 #include "Torrent.hpp"
 
+#include <sstream>
+
 #include <libtorrent/create_torrent.hpp>
 #include <libtorrent/torrent_info.hpp>
 
@@ -12,7 +14,7 @@
 namespace lt = libtorrent;
 using Core::Torrent;
 
-void Torrent::Save(const boost::shared_ptr<const lt::torrent_info>& ti, std::error_code& ec)
+void Torrent::Save(const std::shared_ptr<const lt::torrent_info>& ti, std::error_code& ec)
 {
     lt::create_torrent ct(*ti);
     lt::entry e = ct.generate();
@@ -23,8 +25,9 @@ void Torrent::Save(const boost::shared_ptr<const lt::torrent_info>& ti, std::err
     std::wstring torrents_dir = IO::Path::Combine(Environment::GetDataPath(), TEXT("Torrents"));
     if (!IO::Directory::Exists(torrents_dir)) { IO::Directory::Create(torrents_dir); }
 
-    std::string hash = lt::to_hex(ti->info_hash().to_string());
-    std::string file_name = hash + ".torrent";
+    std::stringstream hex;
+    hex << ti->info_hash();
+    std::string file_name = hex.str() + ".torrent";
 
     std::wstring torrent_file = IO::Path::Combine(torrents_dir, TWS(file_name));
     IO::File::WriteAllBytes(torrent_file, buf, ec);

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Cake" version="0.8.0" />
   <package id="Cake.CMake" version="0.0.2" />
-  <package id="PicoTorrent.Libs" version="0.10.0" />
+  <package id="PicoTorrent.Libs" version="0.11.0" />
   <package id="WiX" version="3.10.2" />
 </packages>


### PR DESCRIPTION
This updates Rasterbar-libtorrent to the latest master (as of now), Boost to 1.61 and OpenSSL to 1.0.2h.