### PR TITLE
GH293: Enable/disable DHT and LSD

### DIFF
--- a/docs/src/configuration.rst
+++ b/docs/src/configuration.rst
@@ -55,6 +55,12 @@ directly).
         // The max number of torrents to announce to their trackers.
         "active_tracker_limit": 1600,
 
+        // Set to `true` to enable DHT.
+        "enable_dht": true,
+
+        // Set to `true` to enable LSD (Local Service Discovery).
+        "enable_lsd": true,
+
         // Set to `true` to require encryption for incoming connections.
         "require_incoming_encryption": false,
 

--- a/src/Configuration.hpp
+++ b/src/Configuration.hpp
@@ -71,6 +71,11 @@ public:
         int GetActiveSeeds();
         int GetActiveTrackerLimit();
 
+        bool GetEnableDht();
+        void SetEnableDht(bool value);
+        bool GetEnableLsd();
+        void SetEnableLsd(bool value);
+
         bool GetRequireIncomingEncryption();
         void SetRequireIncomingEncryption(bool value);
         bool GetRequireOutgoingEncryption();

--- a/src/Configuration_SessionSection.cpp
+++ b/src/Configuration_SessionSection.cpp
@@ -46,6 +46,26 @@ int Configuration::SessionSection::GetActiveTrackerLimit()
     return Get("session", "active_tracker_limit", 1600);
 }
 
+bool Configuration::SessionSection::GetEnableDht()
+{
+    return Get("session", "enable_dht", true);
+}
+
+void Configuration::SessionSection::SetEnableDht(bool value)
+{
+    Set("session", "enable_dht", value);
+}
+
+bool Configuration::SessionSection::GetEnableLsd()
+{
+    return Get("session", "enable_lsd", true);
+}
+
+void Configuration::SessionSection::SetEnableLsd(bool value)
+{
+    Set("session", "enable_lsd", value);
+}
+
 int Configuration::SessionSection::GetDownloadRateLimit()
 {
     return Get("session", "download_rate_limit", 0);

--- a/src/core/SessionSettings.cpp
+++ b/src/core/SessionSettings.cpp
@@ -25,6 +25,10 @@ lt::settings_pack SessionSettings::Get()
         ifaces << "," << p.first << ":" << p.second;
     }
 
+    // Features
+    settings.set_bool(lt::settings_pack::enable_dht, cfg.Session()->GetEnableDht());
+    settings.set_bool(lt::settings_pack::enable_lsd, cfg.Session()->GetEnableLsd());
+
     // Limits
     settings.set_int(lt::settings_pack::active_checking, cfg.Session()->GetActiveChecking());
     settings.set_int(lt::settings_pack::active_dht_limit, cfg.Session()->GetActiveDhtLimit());


### PR DESCRIPTION
This fixes the relevant parts of #293 by giving the user a client-wide option to disable DHT and LSD.

Closes #293.