### PR TITLE
Fix an unhandled exception when calling WriteFile

### DIFF
--- a/src/IO/File.cpp
+++ b/src/IO/File.cpp
@@ -85,11 +85,13 @@ void File::WriteAllBytes(const std::wstring& path, const std::vector<char>& buf,
         return;
     }
 
+    DWORD lpBytesWritten = 0;
+
     if (!WriteFile(
         handle.get(),
         &buf[0],
         (DWORD)buf.size(),
-        NULL,
+        &lpBytesWritten,
         NULL))
     {
         ec.assign(GetLastError(), std::system_category());


### PR DESCRIPTION
If passing `NULL` to `lpOverlapped`, the `lpNumberOfBytesWritten` parameter can not be `NULL` as well. Worked OK on Windows 10, though.