### PR TITLE
GH344: Small fix for the empty torrent list

### DIFF
--- a/src/Environment.cpp
+++ b/src/Environment.cpp
@@ -3,6 +3,8 @@
 #include <windows.h>
 #include <shlwapi.h>
 
+#include "IO/Path.hpp"
+
 std::wstring Environment::GetApplicationPath()
 {
     TCHAR buf[MAX_PATH];
@@ -15,7 +17,9 @@ std::wstring Environment::GetDataPath()
 {
     if (IsInstalled())
     {
-        return GetKnownFolderPath(FOLDERID_LocalAppData);
+        return IO::Path::Combine(
+			GetKnownFolderPath(FOLDERID_LocalAppData),
+			TEXT("PicoTorrent"));
     }
 
     return GetApplicationPath();


### PR DESCRIPTION
This fixes the issue when upgrading from 0.10 to 0.11 and receiving an empty torrent list. Users already on 0.11 are recommended to update as well, and will need to manually move data files.

Fixes #344 