### PR TITLE
Use correct default language

### DIFF
--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -56,7 +56,7 @@ void Configuration::SetCloseAction(Configuration::CloseAction action)
 
 int Configuration::GetCurrentLanguageId()
 {
-    return Get("language_id", (int)GetUserDefaultLangID());
+    return Get("language_id", (int)GetUserDefaultUILanguage());
 }
 
 void Configuration::SetCurrentLanguageId(int languageId)


### PR DESCRIPTION
Currently PicoTorrent uses [region settings](https://msdn.microsoft.com/en-us/library/windows/desktop/dd318134.aspx) for the default language, which is not exactly right.

For example, as a Russian user I have my region settings set to Russian, however I prefer using software in English, and my system language is English.

[`GetUserDefaultUILanguage`](https://msdn.microsoft.com/en-us/library/windows/desktop/dd318137.aspx) returns the actual preferred language.