### PR TITLE
Open Torrent Preferences on double click

### DIFF
--- a/src/UI/ListView.cpp
+++ b/src/UI/ListView.cpp
@@ -410,6 +410,13 @@ LRESULT ListView::SubclassProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam
 
             break;
         }
+        case NM_DBLCLK:
+        {
+            LPNMITEMACTIVATE lpnmia = reinterpret_cast<LPNMITEMACTIVATE>(lParam);
+            std::vector<int> indices{ lpnmia->iItem };
+            lv->OnItemActivated(indices);
+            break;
+        }
         case LVN_GETDISPINFO:
         {
             NMLVDISPINFO* inf = reinterpret_cast<NMLVDISPINFO*>(nmhdr);

--- a/src/UI/ListView.hpp
+++ b/src/UI/ListView.hpp
@@ -44,6 +44,7 @@ protected:
     virtual int GetItemIconIndex(int itemIndex) { return -1; }
     virtual float GetItemProgress(int columnId, int itemIndex) { return -1; }
     virtual std::wstring GetItemText(int columnId, int itemIndex) = 0;
+    virtual void OnItemActivated(std::vector<int> const& selectedIndices) { }
     virtual void ToggleItemState(const std::vector<int>& selectedIndices) { }
     virtual void ShowContextMenu(POINT p, const std::vector<int>& selectedIndices) { };
     virtual bool Sort(int columnId, SortOrder order) { return false; }

--- a/src/UI/TorrentListView.cpp
+++ b/src/UI/TorrentListView.cpp
@@ -326,6 +326,23 @@ std::wstring TorrentListView::GetItemText(int columnId, int itemIndex)
     return TEXT("?unknown?");
 }
 
+void TorrentListView::OnItemActivated(std::vector<int> const& indices)
+{
+    if (indices.size() != 1)
+    {
+        return;
+    }
+
+    std::vector<Torrent> selection;
+    std::for_each(
+        indices.begin(),
+        indices.end(),
+        [this, &selection](int i) { selection.push_back(m_models.at(i)); });
+
+    Commands::ShowTorrentDetailsCommand show{ selection[0] };
+    SendCommand(PT_SHOWTORRENTDETAILS, reinterpret_cast<LPARAM>(&show));
+}
+
 void TorrentListView::ShowContextMenu(POINT p, const std::vector<int>& sel)
 {
     if (sel.empty())

--- a/src/UI/TorrentListView.hpp
+++ b/src/UI/TorrentListView.hpp
@@ -25,6 +25,7 @@ namespace UI
         int GetItemIconIndex(int itemIndex);
         float GetItemProgress(int columnId, int itemIndex);
         std::wstring GetItemText(int columnId, int itemIndex);
+        void OnItemActivated(std::vector<int> const& indices);
         void ShowContextMenu(POINT p, const std::vector<int>& selectedIndices);
         bool Sort(int columnId, SortOrder order);
 


### PR DESCRIPTION
This will open the torrent preferences dialog when you double click a torrent. I think this is the best behavior for double clicks since it is the least surprise for the user.

Closes #400 