### PR TITLE
Use GetMessagePos for NotifyIcon context menu position

### DIFF
--- a/src/Controllers/NotifyIconController.cpp
+++ b/src/Controllers/NotifyIconController.cpp
@@ -29,7 +29,8 @@ void NotifyIconController::Execute(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_CONTEXTMENU:
     {
-        POINT p{ GET_X_LPARAM(wParam), GET_Y_LPARAM(wParam) };
+        DWORD dwPos = GetMessagePos();
+        POINT p{ GET_X_LPARAM(dwPos), GET_Y_LPARAM(dwPos) };
 
         HMENU menu = CreatePopupMenu();
         AppendMenu(menu, MF_STRING, ID_NOTIFYICON_ADD, TRW("add_torrent"));


### PR DESCRIPTION
This is a quick fix to solve #398. It does not fix the underlying issue which is that you should restart PicoTorrent when the DPI scaling is changed. We could detect this as well and scale accordingly, but that is out of the scope for now.

Closes #398 
