### PR TITLE
Show selected size in torrent list view

### DIFF
--- a/include/picotorrent/api.hpp
+++ b/include/picotorrent/api.hpp
@@ -184,7 +184,8 @@ struct Torrent
     std::string infoHash;
     std::string name;
     int queuePosition;
-    int64_t size;
+    int64_t totalSize;
+    int64_t totalWanted;
     State state;
     float progress;
     std::chrono::seconds eta;

--- a/plugins/websocket/src/Serialization/TorrentSerializer.cpp
+++ b/plugins/websocket/src/Serialization/TorrentSerializer.cpp
@@ -11,7 +11,8 @@ pj::object TorrentSerializer::Serialize(Torrent const& torrent)
     obj["info_hash"] = pj::value(torrent.infoHash);
     obj["name"] = pj::value(torrent.name);
     obj["queue_position"] = pj::value(static_cast<int64_t>(torrent.queuePosition));
-    obj["size"] = pj::value(torrent.size);
+    obj["size"] = pj::value(torrent.totalWanted);
+    obj["size_total"] = pj::value(torrent.totalSize);
     obj["progress"] = pj::value(torrent.progress);
     obj["status"] = pj::value(static_cast<int64_t>(torrent.state));
 	obj["eta"] = pj::value(static_cast<int64_t>(torrent.eta.count()));

--- a/src/Mapping/TorrentMapper.cpp
+++ b/src/Mapping/TorrentMapper.cpp
@@ -169,6 +169,7 @@ Torrent TorrentMapper::Map(libtorrent::torrent_status const& status)
         status.name.empty() ? ss.str() : status.name,
         status.queue_position,
         totalSize,
+        status.total_wanted,
         state,
         status.progress,
         std::chrono::seconds(eta),

--- a/src/UI/TorrentListView.cpp
+++ b/src/UI/TorrentListView.cpp
@@ -262,14 +262,39 @@ std::wstring TorrentListView::GetItemText(int columnId, int itemIndex)
     }
     case LV_COL_SIZE:
     {
-        if (m_models.at(itemIndex).size < 0)
+        Torrent& t = m_models.at(itemIndex);
+
+        if (t.totalSize < 0)
         {
             return L"-";
         }
 
-        TCHAR s[100];
-        StrFormatByteSize64(m_models.at(itemIndex).size, s, ARRAYSIZE(s));
-        return s;
+        TCHAR wanted[100];
+        StrFormatByteSize64(
+            t.totalWanted,
+            wanted,
+            ARRAYSIZE(wanted));
+
+        if (t.totalSize == t.totalWanted)
+        {
+            return wanted;
+        }
+
+        TCHAR total[100];
+        StrFormatByteSize64(
+            t.totalSize,
+            total,
+            ARRAYSIZE(total));
+
+        TCHAR text[200];
+        StringCchPrintf(
+            text,
+            ARRAYSIZE(text),
+            TEXT("%s (%s)"),
+            wanted,
+            total);
+
+        return text;
     }
     case LV_COL_STATUS:
     {
@@ -590,8 +615,8 @@ bool TorrentListView::Sort(int columnId, ListView::SortOrder order)
     {
         sorter = [asc](const Torrent& t1, const Torrent& t2)
         {
-            if (asc) return t1.size < t2.size;
-            return t1.size > t2.size;
+            if (asc) return t1.totalWanted < t2.totalWanted;
+            return t1.totalWanted > t2.totalWanted;
         };
         break;
     }


### PR DESCRIPTION
If a user has chosen to not download some files in a torrent, the Size column now shows the size of the selected torrents as well as the total size. For torrents where the sizes are the same (ie. all files should download) the column remains the same as always.

![image](https://user-images.githubusercontent.com/1491824/27096460-6ce2939a-5071-11e7-8362-198c2b1feb1f.png)

Closes #421 