### PR TITLE
Upgrade to Visual Studio 2017

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 project("PicoTorrent")
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Rasterbar-libtorrent to provide high performance and low memory usage.
 
 ## Building PicoTorrent
 
-PicoTorrent depends only on what Rasterbar-libtorrent needs (Boost.System,
-and Boost.Random) and all dependencies are conveniently pre-packaged in a
-NuGet package which will be downloaded as a part of the build process.
+PicoTorrent depends only on what Rasterbar-libtorrent needs (Boost.System
+and OpenSSL) and all dependencies are conveniently pre-packaged in a NuGet
+package which will be downloaded as a part of the build process.
 
 To successfully build PicoTorrent, you need the following tools installed,
 
-- CMake (>= v2.8) (installed and added to `PATH`)
-- Visual Studio 2015 (Community edition) (with C++ toolset installed)
-- Chocolatey (>= v0.9.9.11)
+- CMake (>= v3.8) (installed and added to `PATH`)
+- Visual Studio 2017 (w/ C++ toolset)
+- Chocolatey (>= v0.10.7)
 
 Build PicoTorrent by running the following in a PowerShell prompt,
 
@@ -39,5 +39,5 @@ PS> .\build.ps1
 
 ## License
 
-Copyright (c) 2015, Viktor Elofsson and contributors. PicoTorrent is provided
+Copyright (c) Viktor Elofsson and contributors. PicoTorrent is provided
 as-is under the MIT license. For more information see [LICENSE](LICENSE).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 # AppVeyor build configuration
 
-os: Visual Studio 2015
+os: Visual Studio 2017
 
 branches:
   except:

--- a/build.cake
+++ b/build.cake
@@ -65,11 +65,11 @@ Task("Generate-Project")
     .IsDependentOn("Clean")
     .Does(() =>
 {
-    var generator = "Visual Studio 14 Win64";
+    var generator = "Visual Studio 15 2017 Win64";
 
     if(platform == "x86")
     {
-        generator = "Visual Studio 14";
+        generator = "Visual Studio 15 2017";
     }
 
     CMake("./", new CMakeSettings {
@@ -172,7 +172,7 @@ Task("Build-AppX-Package")
     argsBuilder.Append("/f {0}", MakeAbsolute(File("./packaging/AppX/PicoTorrent.mapping")));
     argsBuilder.Append("/p {0}", MakeAbsolute(PackagesDirectory + File(AppXPackage)));
 
-    var makeAppXTool = "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\makeappx.exe";
+    var makeAppXTool = "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.15063.0\\x86\\makeappx.exe";
     int exitCode = StartProcess(makeAppXTool, new ProcessSettings
     {
         Arguments = argsBuilder

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Cake" version="0.17.0" />
-  <package id="Cake.CMake" version="0.0.2" />
+  <package id="Cake" version="0.20.0" />
+  <package id="Cake.CMake" version="0.2.2" />
   <package id="PicoTorrent.Libs" version="0.12.0" />
   <package id="WiX" version="3.10.2" />
 </packages>


### PR DESCRIPTION
This upgrades the CMake generator, MSBuild toolset and AppVeyor image to Visual Studio 2017. Until we have upgraded our dependencies to MSVC 14.1, we will still use MSVC 14.0.