### PR TITLE
Fix lang_id typo in Hungarian translation file

### DIFF
--- a/lang/1038.json
+++ b/lang/1038.json
@@ -1,5 +1,5 @@
 {
-    "lang_id": 1043,
+    "lang_id": 1038,
     "lang_name": "Magyar",
     "strings":
     {


### PR DESCRIPTION
The translation file for Hungarian (added in #384) had a wrong Locale ID (`1043` instead of the correct `1038`).
When the file was renamed in #422 (`1043.json` ➡️ `1038.json`) the `lang_id` value inside the file stayed at `1043`.