### PR TITLE
GH469: Activate application on single left click on notify icon

### DIFF
--- a/src/picotorrent/taskbaricon.cpp
+++ b/src/picotorrent/taskbaricon.cpp
@@ -16,7 +16,7 @@ wxBEGIN_EVENT_TABLE(TaskBarIcon, wxTaskBarIcon)
     EVT_MENU(ptID_ADD_MAGNET_LINK, TaskBarIcon::OnAddMagnetLink)
     EVT_MENU(ptID_PREFERENCES, TaskBarIcon::OnViewPreferences)
     EVT_MENU(wxID_EXIT, TaskBarIcon::OnExit)
-    EVT_TASKBAR_LEFT_DCLICK(TaskBarIcon::OnLeftButtonDClick)
+    EVT_TASKBAR_LEFT_DOWN(TaskBarIcon::OnLeftButtonDown)
 wxEND_EVENT_TABLE()
 
 TaskBarIcon::TaskBarIcon(wxFrame* parent,
@@ -67,7 +67,7 @@ void TaskBarIcon::OnExit(wxCommandEvent& WXUNUSED(event))
     m_parent->Close(true);
 }
 
-void TaskBarIcon::OnLeftButtonDClick(wxTaskBarIconEvent& WXUNUSED(event))
+void TaskBarIcon::OnLeftButtonDown(wxTaskBarIconEvent& WXUNUSED(event))
 {
     m_parent->MSWGetTaskBarButton()->Show();
     m_parent->Restore();

--- a/src/picotorrent/taskbaricon.hpp
+++ b/src/picotorrent/taskbaricon.hpp
@@ -42,7 +42,7 @@ namespace pt
         void OnAddTorrent(wxCommandEvent&);
         void OnAddMagnetLink(wxCommandEvent&);
         void OnExit(wxCommandEvent&);
-        void OnLeftButtonDClick(wxTaskBarIconEvent&);
+        void OnLeftButtonDown(wxTaskBarIconEvent&);
         void OnViewPreferences(wxCommandEvent&);
 
         wxFrame* m_parent;


### PR DESCRIPTION
Switching from double click to single click to activate PicoTorrent from the notify icon.