### PR TITLE
GH497: Add support for side-loading translation files

### DIFF
--- a/src/picotorrent/config.cpp
+++ b/src/picotorrent/config.cpp
@@ -63,6 +63,11 @@ void Configuration::CurrentLanguageId(int languageId)
     Set<int>("language_id", languageId);
 }
 
+fs::path Configuration::LanguagesPath()
+{
+    return Get<std::string>("languages_path", (m_env->GetApplicationDataPath() / "Languages").string());
+}
+
 fs::path Configuration::DefaultSavePath()
 {
     return Get<std::string>("default_save_path", m_env->GetKnownFolderPath(Environment::KnownFolder::UserDownloads).string());

--- a/src/picotorrent/config.hpp
+++ b/src/picotorrent/config.hpp
@@ -119,6 +119,8 @@ namespace pt
         int CurrentLanguageId();
         void CurrentLanguageId(int id);
 
+        fs::path LanguagesPath();
+
         fs::path DefaultSavePath();
         void DefaultSavePath(fs::path path);
 

--- a/src/picotorrent/translator.hpp
+++ b/src/picotorrent/translator.hpp
@@ -14,6 +14,7 @@
 namespace pt
 {
     class Configuration;
+    class Environment;
 
     class Translator
     {
@@ -35,6 +36,7 @@ namespace pt
         Translator(std::map<int, Language> const& languages, int selectedLanguage);
 
         static BOOL CALLBACK LoadTranslationResource(HMODULE hModule, LPCTSTR lpszType, LPTSTR lpszName, LONG_PTR lParam);
+        static bool LoadLanguageFromJson(std::string const& json, Language& lang);
 
         int m_selectedLanguage;
         std::map<int, Language> m_languages;


### PR DESCRIPTION
This will add support for loading translation files from a separate directory. The bundled translations will still be embedded in the executable, but more translations can be added by putting them in a `Translations` directory in the data path (`cwd` for portable installs, AppData for installations).

The path can also be overridden by editing the `languages_path` config key, which means you can put them wherever 😄 