### PR TITLE
Improve add torrent dialog and add sequential download

### DIFF
--- a/lang/1033.json
+++ b/lang/1033.json
@@ -222,6 +222,8 @@
         "enable_lsd": "Enable LSD",
         "enable_pex": "Enable PeX",
         "changing_pex_settings_requires_restart": "Changing the PeX setting requires a restart",
-        "restart_required": "Restart required"
+        "restart_required": "Restart required",
+        "file": "File",
+        "comment": "Comment"
     }
 }

--- a/src/picotorrent/addtorrentdlg.cpp
+++ b/src/picotorrent/addtorrentdlg.cpp
@@ -30,7 +30,7 @@ wxEND_EVENT_TABLE()
 AddTorrentDialog::AddTorrentDialog(wxWindow* parent,
     std::shared_ptr<pt::Translator> translator,
     std::vector<lt::add_torrent_params>& params)
-    : wxDialog(parent, wxID_ANY, i18n(translator, "add_torrent_s"), wxDefaultPosition, wxSize(400, 500), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+    : wxDialog(parent, wxID_ANY, i18n(translator, "add_torrent_s"), wxDefaultPosition, wxSize(400, 530), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
     m_params(params),
     m_trans(translator),
     m_filesViewModel(new FileStorageViewModel(translator))
@@ -52,12 +52,15 @@ AddTorrentDialog::AddTorrentDialog(wxWindow* parent,
     m_name = new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
     m_size = new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
     m_comment = new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
+    m_infoHash = new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
 
     torrentGrid->AddGrowableCol(1, 1);
     torrentGrid->Add(new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, m_trans->Translate("name")));
     torrentGrid->Add(m_name, 0, wxEXPAND);
     torrentGrid->Add(new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, m_trans->Translate("size")));
     torrentGrid->Add(m_size, 0, wxEXPAND);
+    torrentGrid->Add(new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, m_trans->Translate("info_hash")));
+    torrentGrid->Add(m_infoHash, 0, wxEXPAND);
     torrentGrid->Add(new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, m_trans->Translate("comment")));
     torrentGrid->Add(m_comment, 0, wxEXPAND);
     torrentSizer->Add(torrentGrid, 1, wxEXPAND | wxALL, 5);
@@ -155,6 +158,7 @@ void AddTorrentDialog::LoadTorrentInfo(int index)
     m_name->SetLabel("-");
     m_size->SetLabel("-");
     m_comment->SetLabel("-");
+    m_infoHash->SetLabel("-");
 
     // Save path
     m_savePath->SetPath(params.save_path);
@@ -163,13 +167,18 @@ void AddTorrentDialog::LoadTorrentInfo(int index)
     {
         m_name->SetLabel(params.ti->name());
 
+        std::stringstream ss;
+        ss << params.ti->info_hash();
+
+        m_infoHash->SetLabel(ss.str());
+
+        // Size
+        m_size->SetLabel(wxString(Utils::ToHumanFileSize(params.ti->total_size())));
+
         if (!params.ti->comment().empty())
         {
             m_comment->SetLabel(params.ti->comment());
         }
-
-        // Size
-        m_size->SetLabel(wxString(Utils::ToHumanFileSize(params.ti->total_size())));
 
         // Files
         m_filesViewModel->RebuildTree(params.ti);
@@ -178,6 +187,14 @@ void AddTorrentDialog::LoadTorrentInfo(int index)
     }
     else
     {
+        if (!params.info_hash.is_all_zeros())
+        {
+            std::stringstream ss;
+            ss << params.info_hash;
+
+            m_infoHash->SetLabel(ss.str());
+        }
+
         m_size->SetLabel("-");
         m_filesViewModel->Cleared();
     }

--- a/src/picotorrent/addtorrentdlg.cpp
+++ b/src/picotorrent/addtorrentdlg.cpp
@@ -9,6 +9,8 @@
 #include <libtorrent/torrent_info.hpp>
 #include <wx/dataview.h>
 #include <wx/filepicker.h>
+#include <wx/persist.h>
+#include <wx/persist/toplevel.h>
 
 #include <shellapi.h>
 
@@ -28,56 +30,45 @@ wxEND_EVENT_TABLE()
 AddTorrentDialog::AddTorrentDialog(wxWindow* parent,
     std::shared_ptr<pt::Translator> translator,
     std::vector<lt::add_torrent_params>& params)
-    : wxDialog(parent, wxID_ANY, i18n(translator, "add_torrent_s"), wxDefaultPosition, wxSize(400, 400)),
+    : wxDialog(parent, wxID_ANY, i18n(translator, "add_torrent_s"), wxDefaultPosition, wxSize(400, 500), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
     m_params(params),
     m_trans(translator),
     m_filesViewModel(new FileStorageViewModel(translator))
 {
-    wxPanel* panel = new wxPanel(this, wxID_ANY);
-    m_torrents = new wxChoice(panel, ptID_TORRENT_LIST);
-    m_size = new wxStaticText(panel, wxID_ANY, wxEmptyString);
-    m_savePath = new wxDirPickerCtrl(panel, ptID_SAVE_PATH, wxEmptyString, wxDirSelectorPromptStr, wxDefaultPosition, wxDefaultSize, wxDIRP_DEFAULT_STYLE | wxDIRP_SMALL);
-    m_filesView = new wxDataViewCtrl(panel, ptID_FILE_LIST);
+    this->SetName("AddTorrentDialog");
+    this->SetMinSize(this->GetSize());
 
-    wxFlexGridSizer* flexGrid = new wxFlexGridSizer(3, 2, 9, 25);
-    flexGrid->AddGrowableCol(1, 1);
+    wxPanel* pnl = new wxPanel(this, wxID_ANY);
+
+    // File
+    wxStaticBoxSizer* fileSizer = new wxStaticBoxSizer(wxVERTICAL, pnl, i18n(translator, "file"));
+    m_torrents = new wxChoice(fileSizer->GetStaticBox(), ptID_TORRENT_LIST);
+    fileSizer->Add(m_torrents, 0, wxEXPAND | wxALL, 5);
 
     // Torrent
-    flexGrid->Add(new wxStaticText(panel, wxID_ANY, m_trans->Translate("torrent")), 0, wxALIGN_CENTER_VERTICAL);
+    wxStaticBoxSizer* torrentSizer = new wxStaticBoxSizer(wxVERTICAL, pnl, i18n(translator, "torrent"));
+    wxFlexGridSizer* torrentGrid = new wxFlexGridSizer(2, 10, 25);
 
-    for (lt::add_torrent_params& p : m_params)
-    {
-        wxString name = "<unknown name>";
+    m_name = new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
+    m_size = new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
+    m_comment = new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxST_ELLIPSIZE_END);
 
-        if (p.ti)
-        {
-            name = p.ti->name();
-        }
-        else if (!p.name.empty())
-        {
-            name = p.name;
-        }
-        else
-        {
-            std::stringstream ss;
-            ss << p.info_hash;
-            name = ss.str();
-        }
+    torrentGrid->AddGrowableCol(1, 1);
+    torrentGrid->Add(new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, m_trans->Translate("name")));
+    torrentGrid->Add(m_name, 0, wxEXPAND);
+    torrentGrid->Add(new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, m_trans->Translate("size")));
+    torrentGrid->Add(m_size, 0, wxEXPAND);
+    torrentGrid->Add(new wxStaticText(torrentSizer->GetStaticBox(), wxID_ANY, m_trans->Translate("comment")));
+    torrentGrid->Add(m_comment, 0, wxEXPAND);
+    torrentSizer->Add(torrentGrid, 1, wxEXPAND | wxALL, 5);
 
-        m_torrents->Insert(name, 0);
-    }
+    // Storage
+    wxStaticBoxSizer* storageSizer = new wxStaticBoxSizer(wxVERTICAL, pnl, i18n(translator, "storage"));
+    wxFlexGridSizer* storageGrid = new wxFlexGridSizer(2, 10, 25);
 
-    flexGrid->Add(m_torrents, 1, wxEXPAND);
-
-    // Size
-    flexGrid->Add(new wxStaticText(panel, wxID_ANY, m_trans->Translate("size")), 0, wxALIGN_CENTER_VERTICAL);
-    flexGrid->Add(m_size);
-
-    // Save path
-    flexGrid->Add(new wxStaticText(panel, wxID_ANY, m_trans->Translate("save_path")), 0, wxALIGN_CENTER_VERTICAL);
-    flexGrid->Add(m_savePath, 1, wxEXPAND);
-
-    // File tree
+    m_savePath = new wxDirPickerCtrl(storageSizer->GetStaticBox(), ptID_SAVE_PATH, wxEmptyString, wxDirSelectorPromptStr, wxDefaultPosition, wxDefaultSize, wxDIRP_DEFAULT_STYLE | wxDIRP_SMALL);
+    m_filesView = new wxDataViewCtrl(storageSizer->GetStaticBox(), ptID_FILE_LIST);
+    
     auto nameCol = m_filesView->AppendIconTextColumn(
         i18n(m_trans, "name"),
         FileStorageViewModel::Columns::Name,
@@ -105,16 +96,53 @@ AddTorrentDialog::AddTorrentDialog(wxWindow* parent,
     m_filesView->AssociateModel(m_filesViewModel);
     m_filesViewModel->DecRef();
 
-    wxBoxSizer* buttonsSizer = new wxBoxSizer(wxHORIZONTAL);
-    buttonsSizer->Add(new wxButton(panel, wxID_OK));
-    buttonsSizer->Add(new wxButton(panel, wxID_CANCEL));
+    storageGrid->AddGrowableCol(1, 1);
+    storageGrid->Add(new wxStaticText(storageSizer->GetStaticBox(), wxID_ANY, m_trans->Translate("save_path")), 0, wxALIGN_CENTER_VERTICAL);
+    storageGrid->Add(m_savePath, 1, wxEXPAND);
 
+    storageSizer->Add(storageGrid, 0, wxEXPAND | wxALL, 5);
+    storageSizer->Add(m_filesView, 1, wxEXPAND | wxALL, 5);
+
+    // Buttons
+    wxBoxSizer* buttonsSizer = new wxBoxSizer(wxHORIZONTAL);
+    buttonsSizer->Add(new wxButton(pnl, wxID_OK));
+    buttonsSizer->Add(new wxButton(pnl, wxID_CANCEL));
+
+    // Main sizer
     wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
-    mainSizer->Add(flexGrid, 0, wxALL | wxEXPAND, 5);
-    mainSizer->Add(m_filesView, 1, wxALL | wxEXPAND, 5);
+    mainSizer->Add(fileSizer, 0, wxEXPAND | wxALL, 5);
+    mainSizer->AddSpacer(2);
+    mainSizer->Add(torrentSizer, 0, wxEXPAND | wxALL, 5);
+    mainSizer->AddSpacer(2);
+    mainSizer->Add(storageSizer, 1, wxEXPAND | wxALL, 5);
+    mainSizer->AddSpacer(2);
     mainSizer->Add(buttonsSizer, 0, wxALL | wxALIGN_RIGHT, 5);
 
-    panel->SetSizerAndFit(mainSizer);
+    for (lt::add_torrent_params& p : m_params)
+    {
+        wxString name = "<unknown name>";
+
+        if (p.ti)
+        {
+            name = p.ti->name();
+        }
+        else if (!p.name.empty())
+        {
+            name = p.name;
+        }
+        else
+        {
+            std::stringstream ss;
+            ss << p.info_hash;
+            name = ss.str();
+        }
+
+        m_torrents->Insert(name, 0);
+    }
+
+    pnl->SetSizer(mainSizer);
+
+    wxPersistenceManager::Get().RegisterAndRestore(this);
 
     m_torrents->Select(0);
     LoadTorrentInfo(0);
@@ -124,11 +152,22 @@ void AddTorrentDialog::LoadTorrentInfo(int index)
 {
     lt::add_torrent_params& params = m_params.at(index);
 
+    m_name->SetLabel("-");
+    m_size->SetLabel("-");
+    m_comment->SetLabel("-");
+
     // Save path
     m_savePath->SetPath(params.save_path);
 
     if (params.ti)
     {
+        m_name->SetLabel(params.ti->name());
+
+        if (!params.ti->comment().empty())
+        {
+            m_comment->SetLabel(params.ti->comment());
+        }
+
         // Size
         m_size->SetLabel(wxString(Utils::ToHumanFileSize(params.ti->total_size())));
 

--- a/src/picotorrent/addtorrentdlg.hpp
+++ b/src/picotorrent/addtorrentdlg.hpp
@@ -49,7 +49,9 @@ namespace pt
         wxDECLARE_EVENT_TABLE();
 
         wxChoice* m_torrents;
+        wxStaticText* m_name;
         wxStaticText* m_size;
+        wxStaticText* m_comment;
         wxDirPickerCtrl* m_savePath;
         wxDataViewCtrl* m_filesView;
         FileStorageViewModel* m_filesViewModel;

--- a/src/picotorrent/addtorrentdlg.hpp
+++ b/src/picotorrent/addtorrentdlg.hpp
@@ -36,6 +36,7 @@ namespace pt
         {
             ptID_TORRENT_LIST = wxID_HIGHEST,
             ptID_SAVE_PATH,
+            ptID_SEQUENTIAL_DOWNLOAD,
             ptID_TORRENT_FILE_LIST,
             ptID_FILE_LIST
         };
@@ -44,6 +45,7 @@ namespace pt
         void OnFileContextMenu(wxDataViewEvent&);
         void OnSavePathChanged(wxFileDirPickerEvent&);
         void OnSetPriority(wxCommandEvent&);
+        void OnSequentialDownloadChanged(wxCommandEvent&);
         void OnTorrentChanged(wxCommandEvent&);
 
         wxDECLARE_EVENT_TABLE();
@@ -54,6 +56,7 @@ namespace pt
         wxStaticText* m_comment;
         wxStaticText* m_infoHash;
         wxDirPickerCtrl* m_savePath;
+        wxCheckBox* m_sequentialMode;
         wxDataViewCtrl* m_filesView;
         FileStorageViewModel* m_filesViewModel;
 

--- a/src/picotorrent/addtorrentdlg.hpp
+++ b/src/picotorrent/addtorrentdlg.hpp
@@ -52,6 +52,7 @@ namespace pt
         wxStaticText* m_name;
         wxStaticText* m_size;
         wxStaticText* m_comment;
+        wxStaticText* m_infoHash;
         wxDirPickerCtrl* m_savePath;
         wxDataViewCtrl* m_filesView;
         FileStorageViewModel* m_filesViewModel;

--- a/src/picotorrent/torrentcontextmenu.cpp
+++ b/src/picotorrent/torrentcontextmenu.cpp
@@ -30,6 +30,7 @@ BEGIN_EVENT_TABLE(TorrentContextMenu, wxMenu)
     EVT_MENU(ptID_OPEN_IN_EXPLORER, TorrentContextMenu::OpenInExplorer)
     EVT_MENU(ptID_FORCE_RECHECK, TorrentContextMenu::ForceRecheck)
     EVT_MENU(ptID_FORCE_REANNOUNCE, TorrentContextMenu::ForceReannounce)
+    EVT_MENU(ptID_SEQUENTIAL_DOWNLOAD, TorrentContextMenu::SequentialDownload)
 END_EVENT_TABLE()
 
 TorrentContextMenu::TorrentContextMenu(
@@ -83,6 +84,18 @@ TorrentContextMenu::TorrentContextMenu(
     AppendSeparator();
     Append(ptID_FORCE_REANNOUNCE, i18n(tr, "force_reannounce"));
     Append(ptID_FORCE_RECHECK, i18n(tr, "force_recheck"));
+
+    if (m_state->selected_torrents.size() == 1)
+    {
+        const lt::torrent_handle& th = m_state->selected_torrents.at(0);
+        bool isSequential = (th.flags() & lt::torrent_flags::sequential_download) == lt::torrent_flags::sequential_download;
+
+        wxMenuItem* item = Append(ptID_SEQUENTIAL_DOWNLOAD, i18n(tr, "sequential_download"));
+        item->SetCheckable(true);
+        item->Check(isSequential);
+    }
+
+    AppendSeparator();
     Append(ptID_MOVE, i18n(tr, "move"));
     Append(ptID_REMOVE, i18n(tr, "remove"));
     AppendSeparator();
@@ -221,5 +234,22 @@ void TorrentContextMenu::QueueBottom(wxCommandEvent& WXUNUSED(event))
     for (lt::torrent_handle& th : m_state->selected_torrents)
     {
         th.queue_position_bottom();
+    }
+}
+
+void TorrentContextMenu::SequentialDownload(wxCommandEvent& WXUNUSED(event))
+{
+    for (lt::torrent_handle& th : m_state->selected_torrents)
+    {
+        bool isSequential = (th.flags() & lt::torrent_flags::sequential_download) == lt::torrent_flags::sequential_download;
+
+        if (isSequential)
+        {
+            th.unset_flags(lt::torrent_flags::sequential_download);
+        }
+        else
+        {
+            th.set_flags(lt::torrent_flags::sequential_download);
+        }
     }
 }

--- a/src/picotorrent/torrentcontextmenu.hpp
+++ b/src/picotorrent/torrentcontextmenu.hpp
@@ -33,7 +33,8 @@ namespace pt
             ptID_COPY_INFO_HASH,
             ptID_OPEN_IN_EXPLORER,
             ptID_FORCE_RECHECK,
-            ptID_FORCE_REANNOUNCE
+            ptID_FORCE_REANNOUNCE,
+            ptID_SEQUENTIAL_DOWNLOAD
         };
 
         wxDECLARE_EVENT_TABLE();
@@ -50,6 +51,7 @@ namespace pt
         void QueueDown(wxCommandEvent&);
         void QueueTop(wxCommandEvent&);
         void QueueBottom(wxCommandEvent&);
+        void SequentialDownload(wxCommandEvent&);
 
         wxWindow* m_parent;
         std::shared_ptr<SessionState> m_state;


### PR DESCRIPTION
Some small layout changes to the add torrent dialog. Also adds a sequential download option.

![image](https://user-images.githubusercontent.com/1491824/37067169-e54e52ca-21a8-11e8-9083-ad69e7426f8d.png)

![image](https://user-images.githubusercontent.com/1491824/37067181-f7c79cb8-21a8-11e8-9d65-f91567fda487.png)
