### PR TITLE
Update wxWidgets to a version that doesn't handle errors

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,4 +22,8 @@ artifacts:
  - path: build-*/Release/packages/PicoTorrent-*-*.exe
  - path: build-*/Release/packages/PicoTorrent-*-*.zip
 
+cache:
+  - 'tools/Rasterbar-libtorrent -> tools/packages.config'
+  - 'tools/wxWidgets -> tools/packages.config'
+
 test: off

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -6,5 +6,5 @@
 
   <!-- From the MyGet PicoTorrent feed -->
   <package id="Rasterbar-libtorrent" version="0.2.0" />
-  <package id="wxWidgets" version="0.2.0" />
+  <package id="wxWidgets" version="0.3.0" />
 </packages>


### PR DESCRIPTION
We use Breakpad to handle and send exceptions (if the user opts in). wxWidgets got in the way of that. Also added package caching to AppVeyor.