### PR TITLE
GH550: Fix multi-select in Add torrents, add start torrent option

### DIFF
--- a/lang/1033.json
+++ b/lang/1033.json
@@ -225,6 +225,8 @@
         "restart_required": "Restart required",
         "file": "File",
         "comment": "Comment",
-        "skip_add_torrent_dialog": "Skip 'Add torrent' dialog"
+        "skip_add_torrent_dialog": "Skip 'Add torrent' dialog",
+        "start_torrent": "Start torrent",
+        "auto_managed": "Auto managed"
     }
 }

--- a/src/picotorrent/addtorrentdlg.hpp
+++ b/src/picotorrent/addtorrentdlg.hpp
@@ -37,6 +37,7 @@ namespace pt
             ptID_TORRENT_LIST = wxID_HIGHEST,
             ptID_SAVE_PATH,
             ptID_SEQUENTIAL_DOWNLOAD,
+            ptID_START_TORRENT,
             ptID_TORRENT_FILE_LIST,
             ptID_FILE_LIST
         };
@@ -46,6 +47,7 @@ namespace pt
         void OnSavePathChanged(wxFileDirPickerEvent&);
         void OnSetPriority(wxCommandEvent&);
         void OnSequentialDownloadChanged(wxCommandEvent&);
+        void OnStartTorrentChanged(wxCommandEvent&);
         void OnTorrentChanged(wxCommandEvent&);
 
         wxDECLARE_EVENT_TABLE();
@@ -57,6 +59,7 @@ namespace pt
         wxStaticText* m_infoHash;
         wxDirPickerCtrl* m_savePath;
         wxCheckBox* m_sequentialMode;
+        wxCheckBox* m_startTorrent;
         wxDataViewCtrl* m_filesView;
         FileStorageViewModel* m_filesViewModel;
 

--- a/src/picotorrent/torrentcontextmenu.hpp
+++ b/src/picotorrent/torrentcontextmenu.hpp
@@ -34,11 +34,13 @@ namespace pt
             ptID_OPEN_IN_EXPLORER,
             ptID_FORCE_RECHECK,
             ptID_FORCE_REANNOUNCE,
-            ptID_SEQUENTIAL_DOWNLOAD
+            ptID_SEQUENTIAL_DOWNLOAD,
+            ptID_AUTO_MANAGED
         };
 
         wxDECLARE_EVENT_TABLE();
 
+        void AutoManaged(wxCommandEvent&);
         void CopyInfoHash(wxCommandEvent&);
         void ForceReannounce(wxCommandEvent&);
         void ForceRecheck(wxCommandEvent&);


### PR DESCRIPTION
Adds an option to start a torrent as paused, as well as adds multi-select to the add torrent dialog.