### PR TITLE
Extra fixes

### DIFF
--- a/src/picotorrent/filespage.cpp
+++ b/src/picotorrent/filespage.cpp
@@ -59,6 +59,9 @@ FilesPage::FilesPage(wxWindow* parent, wxWindowID id, std::shared_ptr<pt::Transl
         80,
         wxALIGN_RIGHT);
 
+    // Ugly hack to prevent the last "real" column from stretching.
+    m_filesView->AppendColumn(new wxDataViewColumn(wxEmptyString, new wxDataViewTextRenderer(), -1, 0));
+
     nameCol->GetRenderer()->EnableEllipsize(wxELLIPSIZE_END);
 
     m_filesView->AssociateModel(m_viewModel);

--- a/src/picotorrent/overviewpage.cpp
+++ b/src/picotorrent/overviewpage.cpp
@@ -81,7 +81,7 @@ void OverviewPage::Update(lt::torrent_status const& ts)
     wxString savePath = wxString::FromUTF8(ts.save_path);
     savePath.Replace("&", "&&");
 
-    m_name->SetLabel(ts.name);
+    m_name->SetLabel(wxString::FromUTF8(ts.name));
     m_infoHash->SetLabel(ih.str());
     m_savePath->SetLabel(savePath);
     m_pieces->SetLabel(wxString::Format("%d (of %d)", ts.pieces.count(), ts.pieces.size()));

--- a/src/picotorrent/peerspage.cpp
+++ b/src/picotorrent/peerspage.cpp
@@ -22,6 +22,9 @@ PeersPage::PeersPage(wxWindow* parent, wxWindowID id, std::shared_ptr<pt::Transl
     m_peersView->AppendTextColumn(i18n(tr, "ul"), PeersViewModel::Columns::UploadRate, wxDATAVIEW_CELL_INERT, 80, wxALIGN_RIGHT);
     m_peersView->AppendProgressColumn(i18n(tr, "progress"), PeersViewModel::Columns::Progress, wxDATAVIEW_CELL_INERT, 100);
 
+    // Ugly hack to prevent the last "real" column from stretching.
+    m_peersView->AppendColumn(new wxDataViewColumn(wxEmptyString, new wxDataViewTextRenderer(), -1, 0));
+
     m_peersView->AssociateModel(m_viewModel);
     m_viewModel->DecRef();
 

--- a/src/picotorrent/torrentlistview.cpp
+++ b/src/picotorrent/torrentlistview.cpp
@@ -116,6 +116,9 @@ TorrentListView::TorrentListView(wxWindow* parent, wxWindowID id, std::shared_pt
         wxALIGN_RIGHT,
         wxDATAVIEW_COL_RESIZABLE | wxDATAVIEW_COL_SORTABLE);
 
+    // Ugly hack to prevent the last "real" column from stretching.
+    AppendColumn(new wxDataViewColumn(wxEmptyString, new wxDataViewTextRenderer(), -1, 0));
+
     nameCol->GetRenderer()->EnableEllipsize(wxELLIPSIZE_END);
     statusCol->GetRenderer()->EnableEllipsize(wxELLIPSIZE_END);
 }

--- a/src/picotorrent/trackerspage.cpp
+++ b/src/picotorrent/trackerspage.cpp
@@ -59,6 +59,9 @@ TrackersPage::TrackersPage(wxWindow* parent, wxWindowID id, std::shared_ptr<pt::
         100,
         wxALIGN_RIGHT)->SetMinWidth(100);
 
+    // Ugly hack to prevent the last "real" column from stretching.
+    m_trackersView->AppendColumn(new wxDataViewColumn(wxEmptyString, new wxDataViewTextRenderer(), -1, 0));
+
     m_trackersView->AssociateModel(m_viewModel);
     m_viewModel->DecRef();
 


### PR DESCRIPTION
- UTF8 encode torrent name in overview
- Add hidden last column to list views so they don't stretch and look bad