### PR TITLE
GH587: Set OK button as default in Add torrent dialog

### DIFF
--- a/src/picotorrent/addtorrentdlg.cpp
+++ b/src/picotorrent/addtorrentdlg.cpp
@@ -119,7 +119,11 @@ AddTorrentDialog::AddTorrentDialog(wxWindow* parent,
 
     // Buttons
     wxBoxSizer* buttonsSizer = new wxBoxSizer(wxHORIZONTAL);
-    buttonsSizer->Add(new wxButton(pnl, wxID_OK));
+
+    wxButton* ok = new wxButton(pnl, wxID_OK);
+    ok->SetDefault();
+
+    buttonsSizer->Add(ok);
     buttonsSizer->Add(new wxButton(pnl, wxID_CANCEL));
 
     // Main sizer


### PR DESCRIPTION
Allows users to press enter in the Add torrent dialog to accept and add the torrent.