### PR TITLE
Add option to encrypt configuration file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ add_executable(
 
     src/picotorrent/addtorrentdlg
     src/picotorrent/addtorrentproc
+    src/picotorrent/advancedpage
     src/picotorrent/application
     src/picotorrent/applicationoptions
     src/picotorrent/applicationupdater

--- a/lang/1033.json
+++ b/lang/1033.json
@@ -233,6 +233,7 @@
         "dht_disabled": "DHT: disabled",
         "dht_i64d_nodes": "DHT: %I64d node(s)",
         "i64d_torrents": "%I64d torrent(s)",
-        "dl_s_ul_s": "DL: %s/s, UL: %s/s"
+        "dl_s_ul_s": "DL: %s/s, UL: %s/s",
+        "encrypt_config_file": "Encrypt configuration file"
     }
 }

--- a/src/picotorrent/advancedpage.cpp
+++ b/src/picotorrent/advancedpage.cpp
@@ -1,0 +1,35 @@
+#include "advancedpage.hpp"
+
+#include "config.hpp"
+#include "string.hpp"
+#include "translator.hpp"
+
+#include <wx/propgrid/propgrid.h>
+
+using pt::AdvancedPage;
+
+AdvancedPage::AdvancedPage(wxWindow* parent, std::shared_ptr<pt::Configuration> config, std::shared_ptr<pt::Translator> tr)
+    : wxPanel(parent, wxID_ANY),
+    m_parent(parent),
+    m_cfg(config),
+    m_translator(tr)
+{
+    m_pg = new wxPropertyGrid(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxPG_SPLITTER_AUTO_CENTER);
+    m_pg->Append(new wxBoolProperty(i18n(tr, "encrypt_config_file"), "EncryptConfigFile", config->EncryptConfigurationFile()));
+    m_pg->SetPropertyAttributeAll(wxPG_BOOL_USE_CHECKBOX, true);
+
+    wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->Add(m_pg, 1, wxEXPAND | wxALL, 5);
+
+    this->SetSizerAndFit(sizer);
+}
+
+void AdvancedPage::ApplyConfiguration()
+{
+    m_cfg->EncryptConfigurationFile(m_pg->GetProperty("EncryptConfigFile")->GetValue());
+}
+
+bool AdvancedPage::ValidateConfiguration(wxString& error)
+{
+    return true;
+}

--- a/src/picotorrent/advancedpage.hpp
+++ b/src/picotorrent/advancedpage.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include <memory>
+
+class wxPropertyGrid;
+
+namespace pt
+{
+    class Configuration;
+    class Translator;
+
+    class AdvancedPage : public wxPanel
+    {
+    public:
+        AdvancedPage(wxWindow* parent, std::shared_ptr<Configuration> config, std::shared_ptr<Translator> translator);
+
+        void ApplyConfiguration();
+        bool ValidateConfiguration(wxString& error);
+
+    private:
+        wxWindow* m_parent;
+        wxPropertyGrid* m_pg;
+
+        std::shared_ptr<Configuration> m_cfg;
+        std::shared_ptr<Translator> m_translator;
+    };
+}

--- a/src/picotorrent/config.hpp
+++ b/src/picotorrent/config.hpp
@@ -126,6 +126,9 @@ namespace pt
 
         fs::path LanguagesPath();
 
+        bool EncryptConfigurationFile();
+        void EncryptConfigurationFile(bool val);
+
         fs::path DefaultSavePath();
         void DefaultSavePath(fs::path path);
 

--- a/src/picotorrent/preferencesdlg.cpp
+++ b/src/picotorrent/preferencesdlg.cpp
@@ -1,5 +1,6 @@
 #include "preferencesdlg.hpp"
 
+#include "advancedpage.hpp"
 #include "config.hpp"
 #include "connectionpage.hpp"
 #include "downloadspage.hpp"
@@ -48,11 +49,13 @@ PreferencesDialog::PreferencesDialog(
     m_downloads = new DownloadsPage(book, cfg, tran);
     m_connection = new ConnectionPage(book, cfg, tran);
     m_proxy = new ProxyPage(book, cfg, tran);
+    m_advanced = new AdvancedPage(book, cfg, tran);
 
     book->AddPage(m_general, i18n(tran, "general"), true);
     book->AddPage(m_downloads, i18n(tran, "downloads"), false);
     book->AddPage(m_connection, i18n(tran, "connection"), false);
     book->AddPage(m_proxy, i18n(tran, "proxy"), false);
+    book->AddPage(m_advanced, i18n(tran, "advanced"), false);
 
     CreateButtons();
     LayoutDialog();
@@ -84,12 +87,18 @@ void PreferencesDialog::OnOk(wxCommandEvent& event)
         GetBookCtrl()->SetSelection(3);
         wxMessageBox("Invalid settings", error, 5L, this); // TODO: translate
     }
+    else if (!m_advanced->ValidateConfiguration(error))
+    {
+        GetBookCtrl()->SetSelection(4);
+        wxMessageBox("Invalid settings", error, 5L, this); // TODO: translate
+    }
     else
     {
         m_general->ApplyConfiguration();
         m_downloads->ApplyConfiguration();
         m_connection->ApplyConfiguration();
         m_proxy->ApplyConfiguration();
+        m_advanced->ApplyConfiguration();
 
         Configuration::Save(m_env, m_cfg);
 

--- a/src/picotorrent/preferencesdlg.hpp
+++ b/src/picotorrent/preferencesdlg.hpp
@@ -12,6 +12,7 @@ class wxBookCtrlEvent;
 
 namespace pt
 {
+    class AdvancedPage;
     class Configuration;
     class ConnectionPage;
     class DownloadsPage;
@@ -47,5 +48,6 @@ namespace pt
         DownloadsPage* m_downloads;
         GeneralPage* m_general;
         ProxyPage* m_proxy;
+        AdvancedPage* m_advanced;
     };
 }


### PR DESCRIPTION
This will add an (advanced) option to enable encryption of the configuration file. We use the standard `CryptProtectData` and `CryptUnprotectData` which is the standard for encrypting data on Windows so security is high.

Encrypting the configuration file should have no other impact than making it non-portable.

![image](https://user-images.githubusercontent.com/1491824/39150969-3ae13d22-4744-11e8-963a-0cae812b00b9.png)
