### PR TITLE
Fix bugs in file list view

### DIFF
--- a/src/picotorrent/filestorageitemdelegate.cpp
+++ b/src/picotorrent/filestorageitemdelegate.cpp
@@ -28,12 +28,14 @@ void FileStorageItemDelegate::paint(QPainter* painter, QStyleOptionViewItem cons
     {
     case FileStorageItemModel::Columns::Progress:
     {
-        int progress = index.data().toDouble() * 100;
+        QVariant data = index.data();
 
-        if (progress < 0)
+        if (!data.isValid())
         {
             break;
         }
+
+        int progress = data.toDouble() * 100;
 
         painter->setFont(*m_font);
 

--- a/src/picotorrent/filestorageitemmodel.cpp
+++ b/src/picotorrent/filestorageitemmodel.cpp
@@ -131,7 +131,7 @@ QVariant FileStorageItemModel::data(QModelIndex const& index, int role) const
         {
             if (item->children.size() > 0)
             {
-                return -99;
+                return QVariant();
             }
 
             if (item->progress > 0)

--- a/src/picotorrent/torrentdetails/torrentfileswidget.cpp
+++ b/src/picotorrent/torrentdetails/torrentfileswidget.cpp
@@ -91,6 +91,8 @@ void TorrentFilesWidget::refresh(QList<pt::TorrentHandle*> const& torrents)
     }
     else
     {
+        m_currentFileCount = ti->num_files();
+
         m_filesModel->rebuildTree(ti);
         m_filesModel->setPriorities(torrent->getFilePriorities());
         m_filesModel->setProgress(progress);


### PR DESCRIPTION
This fixes the following two bugs in the file list view,

* It collapses when refreshing the information.
* It shows *-99* in the progress field for folders.

Closes #738 