### PR TITLE
Schedule the WiX CloseApplications CA to close on install/uninstall

### DIFF
--- a/packaging/WiX/PicoTorrent.wxs
+++ b/packaging/WiX/PicoTorrent.wxs
@@ -30,10 +30,14 @@
         <DirectoryRef Id="TARGETDIR" />
 
         <util:CloseApplication Id="CloseApp"
-                               CloseMessage="yes"
                                Target="PicoTorrent.exe"
                                RebootPrompt="no"
-                               TerminateProcess="1" />
+                               EndSessionMessage="yes" />
+
+        <InstallExecuteSequence>
+            <Custom Action="WixCloseApplications"
+                    Before="InstallValidate">1</Custom>
+        </InstallExecuteSequence>
 
         <Feature Id="F_Complete"
                  Title="PicoTorrent"


### PR DESCRIPTION
This will correctly schedule the CA to run always and close PicoTorrent when performing any installer action.

Closes #739