### PR TITLE
Save state for non-metadata torrents

### DIFF
--- a/res/dbmigrations/20191222212037_create_torrent_magnet_uri_table.sql
+++ b/res/dbmigrations/20191222212037_create_torrent_magnet_uri_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE torrent_magnet_uri (
+    info_hash   TEXT PRIMARY KEY,
+    magnet_uri  TEXT NOT NULL,
+    save_path   TEXT NOT NULL,
+
+    FOREIGN KEY(info_hash) REFERENCES torrent(info_hash)
+);

--- a/src/picotorrent/resources.rc
+++ b/src/picotorrent/resources.rc
@@ -35,6 +35,7 @@ IDI_APPICON ICON DISCARDABLE "..\\..\\res\\app.ico"
 20181212205212_create_session_state_table       DBMIGRATION "..\\..\\res\\dbmigrations\\20181212205212_create_session_state_table.sql"
 20181212213425_create_log_table                 DBMIGRATION "..\\..\\res\\dbmigrations\\20181212213425_create_log_table.sql"
 20190322145531_create_list_state_table          DBMIGRATION "..\\..\\res\\dbmigrations\\20190322145531_create_list_state_table.sql"
+20191222212037_create_torrent_magnet_uri_table  DBMIGRATION "..\\..\\res\\dbmigrations\\20191222212037_create_torrent_magnet_uri_table.sql"
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION        VER_FILE_VERSION

--- a/src/picotorrent/session.cpp
+++ b/src/picotorrent/session.cpp
@@ -292,16 +292,32 @@ void Session::reloadSettings()
 
 void Session::loadTorrents()
 {
-    auto stmt = m_db->statement("SELECT trd.resume_data AS resume_data FROM torrent t\n"
+    auto stmt = m_db->statement("SELECT t.info_hash AS info_hash, tmu.magnet_uri AS magnet_uri, trd.resume_data AS resume_data, tmu.save_path AS save_path FROM torrent t\n"
+        "LEFT JOIN torrent_magnet_uri  tmu ON t.info_hash = tmu.info_hash\n"
         "LEFT JOIN torrent_resume_data trd ON t.info_hash = trd.info_hash\n"
         "ORDER BY t.queue_position ASC");
 
     while (stmt->read())
     {
+        std::string info_hash  = stmt->getString(0);
+        std::string magnet_uri = stmt->getString(1);
+        std::string save_path  = stmt->getString(3);
+
         std::vector<char> resume_data;
-        stmt->getBlob(0, resume_data);
+        stmt->getBlob(2, resume_data);
 
         lt::add_torrent_params params;
+
+        // Always parse magnet uri if it is empty
+        if (!magnet_uri.empty())
+        {
+            params = lt::parse_magnet_uri(magnet_uri);
+        }
+
+        if (!save_path.empty())
+        {
+            params.save_path = save_path;
+        }
 
         if (resume_data.size() > 0)
         {
@@ -534,6 +550,34 @@ void Session::readAlerts()
 
                 m_session->remove_torrent(mra->handle, lt::session::delete_files);
             }
+            else
+            {
+                std::stringstream ss;
+
+                if (infoHash.has_v2())
+                {
+                    ss << infoHash.v2;
+                }
+                else
+                {
+                    ss << infoHash.v1;
+                }
+
+                // if we recieve the metadata for a torrent we are currently interested in,
+                // we can remove the magnet_uri stored for it
+                {
+                    auto stmt = m_db->statement("DELETE FROM torrent_magnet_uri  WHERE info_hash = ?;");
+                    stmt->bind(1, ss.str());
+                    stmt->execute();
+                }
+
+                if (mra->handle.need_save_resume_data())
+                {
+                    mra->handle.save_resume_data(
+                        lt::torrent_handle::flush_disk_cache
+                        | lt::torrent_handle::save_info_dict);
+                }
+            }
 
             break;
         }
@@ -669,6 +713,7 @@ void Session::readAlerts()
             std::vector<std::string> statements =
             {
                 "DELETE FROM torrent_resume_data WHERE info_hash = ?;",
+                "DELETE FROM torrent_magnet_uri  WHERE info_hash = ?;",
                 "DELETE FROM torrent             WHERE info_hash = ?;",
             };
 
@@ -744,7 +789,41 @@ void Session::saveTorrents()
         ++numOutstandingResumeData;
     }
 
-    LOG_F(INFO, "Saving resume data for %d torrent(s)", numOutstandingResumeData);
+    // Save all torrents without metadata
+    auto missingMeta = m_session->get_torrent_status(
+        [this](const lt::torrent_status& st)
+        {
+            return !st.has_metadata;
+        });
+
+    LOG_F(INFO, "Saving data for %d torrent(s)", numOutstandingResumeData + static_cast<int>(missingMeta.size()));
+
+    for (lt::torrent_status& st : missingMeta)
+    {
+        std::stringstream ss;
+
+        if (st.info_hash.has_v2())
+        {
+            ss << st.info_hash.v2;
+        }
+        else
+        {
+            ss << st.info_hash.v1;
+        }
+
+        // Store state
+        auto stmt = m_db->statement("REPLACE INTO torrent (info_hash, queue_position) VALUES (?, ?)");
+        stmt->bind(1, ss.str());
+        stmt->bind(2, static_cast<int>(st.queue_position));
+        stmt->execute();
+
+        // Store the magnet uri
+        stmt = m_db->statement("REPLACE INTO torrent_magnet_uri (info_hash, magnet_uri, save_path) VALUES (?, ?, ?);");
+        stmt->bind(1, ss.str());
+        stmt->bind(2, lt::make_magnet_uri(st.handle));
+        stmt->bind(3, st.handle.status(lt::torrent_handle::query_save_path).save_path);
+        stmt->execute();
+    }
 
     while (numOutstandingResumeData > 0)
     {


### PR DESCRIPTION
This will fix the issue where state for non-metadata torrents (those where we have added a magnet link which haven't found the torrent file yet) are not persisted when PicoTorrent is closed.

Closes #764