### PR TITLE
Missing pause option on queued state

### DIFF
--- a/src/picotorrent/torrentcontextmenu.cpp
+++ b/src/picotorrent/torrentcontextmenu.cpp
@@ -63,7 +63,9 @@ TorrentContextMenu::TorrentContextMenu(QWidget* parent, QList<pt::TorrentHandle*
         m_torrents.end(),
         [](TorrentHandle* th)
         {
-            return th->status().paused && th->status().state != TorrentStatus::UploadingQueued;
+            return th->status().paused
+                && th->status().state != TorrentStatus::UploadingQueued
+                && th->status().state != TorrentStatus::DownloadingQueued;
         });
 
     bool allRunning = std::all_of(

--- a/src/picotorrent/torrentcontextmenu.cpp
+++ b/src/picotorrent/torrentcontextmenu.cpp
@@ -63,7 +63,7 @@ TorrentContextMenu::TorrentContextMenu(QWidget* parent, QList<pt::TorrentHandle*
         m_torrents.end(),
         [](TorrentHandle* th)
         {
-            return th->status().paused;
+            return th->status().paused && th->status().state != TorrentStatus::UploadingQueued;
         });
 
     bool allRunning = std::all_of(


### PR DESCRIPTION
Added missing 'pause' option to context menu when a torrent is in uploading queued state. Fixes #799.

I'm not completely sure if this is the correct solution. My current thought is that the _pause_ option is missing when: the torrent is finished and not uploading (state is `UploadingQueued`). When the torrent is uploading then the state is also uploading, so this bug doesn't happen.