### PR TITLE
Show '-' as DL speed when state is uploading

### DIFF
--- a/src/picotorrent/torrentlistmodel.cpp
+++ b/src/picotorrent/torrentlistmodel.cpp
@@ -189,7 +189,7 @@ QVariant TorrentListModel::data(QModelIndex const& index, int role) const
 
         case Columns::DownloadSpeed:
         {
-            if (status.paused)
+            if (status.paused || status.state == TorrentStatus::Uploading)
             {
                 return "-";
             }


### PR DESCRIPTION
This fixes a cosmetic issue when the DL speed would ramp down.