### PR TITLE
Add support for v2 torrents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,13 @@ endif()
 # --------- libtorrent options
 option(BUILD_SHARED_LIBS    "" off)
 option(deprecated-functions "" off)
+
+# uncomment here when webtorrent support is usable
+# option(webtorrent           "" ON)
+
+# deep inside libtorrent we need to turn off a nlohmann-json dependency
+option(NO_EXAMPLES          "" ON)
+
 # ----------------------------
 
 # --------- nlohmann-json options

--- a/src/picotorrent/bittorrent/torrenthandle.cpp
+++ b/src/picotorrent/bittorrent/torrenthandle.cpp
@@ -238,13 +238,13 @@ TorrentStatus TorrentHandle::Status()
 {
     std::stringstream hash;
 
-    if (m_ts->info_hash.has_v2())
+    if (m_ts->info_hashes.has_v2())
     {
-        hash << m_ts->info_hash.v2;
+        hash << m_ts->info_hashes.v2;
     }
     else
     {
-        hash << m_ts->info_hash.v1;
+        hash << m_ts->info_hashes.v1;
     }
 
     if (!m_th->is_valid())

--- a/src/picotorrent/ui/dialogs/addtorrentdialog.cpp
+++ b/src/picotorrent/ui/dialogs/addtorrentdialog.cpp
@@ -226,7 +226,7 @@ void AddTorrentDialog::MetadataFound(std::shared_ptr<lt::torrent_info> const& ti
     {
         auto& params = m_params.at(i);
 
-        if (params.info_hash == ti->info_hashes())
+        if (params.info_hashes == ti->info_hashes())
         {
             params.ti = ti;
 
@@ -254,8 +254,8 @@ wxString AddTorrentDialog::GetTorrentDisplayName(libtorrent::add_torrent_params 
 
     std::stringstream hash;
 
-    if (params.info_hash.has_v2()) hash << params.info_hash.v2;
-    if (params.info_hash.has_v1()) hash << params.info_hash.v1;
+    if (params.info_hashes.has_v2()) hash << params.info_hashes.v2;
+    if (params.info_hashes.has_v1()) hash << params.info_hashes.v1;
 
     return hash.str();
 }
@@ -285,15 +285,15 @@ wxString AddTorrentDialog::GetTorrentDisplayInfoHash(libtorrent::add_torrent_par
             hash << params.ti->info_hashes().v1;
         }
     }
-    else if (params.info_hash.has_v1() || params.info_hash.has_v2())
+    else if (params.info_hashes.has_v1() || params.info_hashes.has_v2())
     {
-        if (params.info_hash.has_v2())
+        if (params.info_hashes.has_v2())
         {
-            hash << params.info_hash.v2;
+            hash << params.info_hashes.v2;
         }
         else
         {
-            hash << params.info_hash.v1;
+            hash << params.info_hashes.v1;
         }
     }
     else

--- a/src/picotorrent/ui/mainframe.cpp
+++ b/src/picotorrent/ui/mainframe.cpp
@@ -378,11 +378,11 @@ void MainFrame::AddTorrents(std::vector<lt::add_torrent_params>& params)
         // let the session find metadata for us
 
         if (
-            ((p.info_hash.has_v1() && !p.info_hash.v1.is_all_zeros())
-                || (p.info_hash.has_v2() && !p.info_hash.v2.is_all_zeros()))
+            ((p.info_hashes.has_v1() && !p.info_hashes.v1.is_all_zeros())
+                || (p.info_hashes.has_v2() && !p.info_hashes.v2.is_all_zeros()))
             && !p.ti)
         {
-            hashes.push_back(p.info_hash);
+            hashes.push_back(p.info_hashes);
         }
     }
 

--- a/src/picotorrent/ui/models/filestoragemodel.cpp
+++ b/src/picotorrent/ui/models/filestoragemodel.cpp
@@ -170,20 +170,26 @@ void FileStorageModel::RebuildTree(std::shared_ptr<const lt::torrent_info> ti)
         m_root->index = 0;
         m_root->size = files.file_size(lt::file_index_t(0));
 
-        std::string extension = m_root->name.substr(m_root->name.find_last_of("."));
+        std::size_t pos = m_root->name.find_last_of(".");
 
-        SHFILEINFO shfi = { 0 };
-        SHGetFileInfo(
-            wxString(extension).ToStdWstring().c_str(),
-            FILE_ATTRIBUTE_NORMAL,
-            &shfi,
-            sizeof(SHFILEINFO),
-            SHGFI_USEFILEATTRIBUTES | SHGFI_ICON | SHGFI_SMALLICON);
+        if (pos != std::string::npos)
+        {
+            std::string extension = m_root->name.substr(pos);
 
-        wxIcon icon;
-        icon.CreateFromHICON(shfi.hIcon);
+            SHFILEINFO shfi = { 0 };
+            SHGetFileInfo(
+                wxString(extension).ToStdWstring().c_str(),
+                FILE_ATTRIBUTE_NORMAL,
+                &shfi,
+                sizeof(SHFILEINFO),
+                SHGFI_USEFILEATTRIBUTES | SHGFI_ICON | SHGFI_SMALLICON);
 
-        m_icons.insert({ extension, icon });
+            wxIcon icon;
+            icon.CreateFromHICON(shfi.hIcon);
+
+            m_icons.insert({ extension, icon });
+        }
+
         m_map.insert({ 0, m_root });
     }
 


### PR DESCRIPTION
This fixes the last issues with running [BEP52 torrents](https://github.com/bittorrent/bittorrent.org/blob/master/beps/bep_0052.rst) in PicoTorrent. The support was already in libtorrent, and it was mostly field access changes needed in PicoTorrent.