### PR TITLE
Use the 2.0 release candidate for libtorrent instead of master

### DIFF
--- a/src/picotorrent/bittorrent/session.cpp
+++ b/src/picotorrent/bittorrent/session.cpp
@@ -202,7 +202,6 @@ Session::Session(wxEvtHandler* parent, std::shared_ptr<pt::Core::Database> db, s
         });
 
     this->LoadTorrents();
-    this->LoadTorrentsOld();
 
     m_timer->Start(1000, wxTIMER_CONTINUOUS);
 
@@ -670,130 +669,6 @@ void Session::LoadTorrents()
         }
 
         m_session->async_add_torrent(params);
-    }
-}
-
-void Session::LoadTorrentsOld()
-{
-    fs::path dataDirectory = m_env->GetApplicationDataPath();
-    fs::path torrentsDirectory = dataDirectory / "Torrents";
-
-    if (!fs::exists(torrentsDirectory))
-    {
-        return;
-    }
-
-    typedef std::pair<int64_t, SessionLoadItem> prio_item_t;
-    auto comparer = [](const prio_item_t& lhs, const prio_item_t& rhs)
-    {
-        return lhs.first > rhs.first;
-    };
-
-    std::priority_queue<prio_item_t, std::vector<prio_item_t>, decltype(comparer)> queue(comparer);
-    int64_t maxPosition = std::numeric_limits<int64_t>::max();
-
-    for (auto& tmp : fs::directory_iterator(torrentsDirectory))
-    {
-        fs::path datFile = tmp.path();
-
-        if (datFile.extension() != ".dat")
-        {
-            continue;
-        }
-
-        std::ifstream datStream(datFile, std::ios::binary | std::ios::in);
-
-        SessionLoadItem item(datFile);
-        std::stringstream ss;
-        ss << datStream.rdbuf();
-        std::string c = ss.str();
-        item.resume_data.assign(c.begin(), c.end());
-
-        lt::error_code ltec;
-        lt::bdecode_node node = lt::bdecode(item.resume_data, ltec);
-
-        if (ltec || node.type() != lt::bdecode_node::type_t::dict_t)
-        {
-            continue;
-        }
-
-        item.magnet_save_path = node.dict_find_string_value("pT-magnet-savePath");
-        item.magnet_url = node.dict_find_string_value("pT-magnet-url");
-
-        int64_t queuePosition = node.dict_find_int_value("pT-queuePosition", maxPosition);
-        if (queuePosition < 0) { queuePosition = maxPosition; }
-
-        queue.push({ queuePosition, item });
-    }
-
-    while (!queue.empty())
-    {
-        SessionLoadItem item = queue.top().second;
-        queue.pop();
-
-        fs::path torrent_file = fs::path(item.path).replace_extension(".torrent");
-
-        if (!fs::exists(torrent_file)
-            && item.magnet_url.empty())
-        {
-            fs::remove(torrent_file);
-            continue;
-        }
-
-        lt::add_torrent_params params;
-
-        if (!item.resume_data.empty())
-        {
-            lt::error_code ltec;
-            params = lt::read_resume_data(
-                item.resume_data,
-                ltec);
-        }
-
-        if (fs::exists(torrent_file))
-        {
-
-            std::ifstream torrent_input(torrent_file, std::ios::binary);
-            std::stringstream ss;
-            ss << torrent_input.rdbuf();
-            std::string torrent_buf = ss.str();
-
-            lt::bdecode_node node;
-            lt::error_code ltec;
-            lt::bdecode(
-                &torrent_buf[0],
-                &torrent_buf[0] + torrent_buf.size(),
-                node,
-                ltec);
-
-            if (ltec)
-            {
-                continue;
-            }
-
-            params.ti = std::make_shared<lt::torrent_info>(node);
-        }
-
-        if (!item.magnet_url.empty())
-        {
-            lt::error_code ec;
-            lt::parse_magnet_uri(item.magnet_url, params, ec);
-            params.save_path = item.magnet_save_path;
-        }
-
-        m_session->async_add_torrent(params);
-
-        // Remove torrent and dat file
-        std::error_code fec;
-        if (fs::exists(item.path, fec)) fs::remove(item.path, fec);
-        if (fs::exists(torrent_file, fec)) fs::remove(torrent_file, fec);
-    }
-
-    // if torrents dir is empty, remove it
-    std::error_code dec;
-    if (fs::is_empty(torrentsDirectory, dec))
-    {
-        fs::remove(torrentsDirectory, dec);
     }
 }
 

--- a/src/picotorrent/bittorrent/session.hpp
+++ b/src/picotorrent/bittorrent/session.hpp
@@ -88,7 +88,6 @@ namespace BitTorrent
 
     private:
         void LoadTorrents();
-        void LoadTorrentsOld();
         void OnAlert();
         void PauseAfterRecheck(TorrentHandle*);
         void SaveState();


### PR DESCRIPTION
This also removes the old file-based torrent loading function. It's not needed since we switched to SQLite a few versions back.