### PR TITLE
Send size event when we restore the main window

### DIFF
--- a/src/picotorrent/ui/mainframe.cpp
+++ b/src/picotorrent/ui/mainframe.cpp
@@ -612,6 +612,7 @@ void MainFrame::OnTaskBarLeftDown(wxTaskBarIconEvent&)
     this->Restore();
     this->Raise();
     this->Show();
+    this->SendSizeEvent();
 }
 
 void MainFrame::OnViewPreferences(wxCommandEvent&)


### PR DESCRIPTION
Call `SendSizeEvent` on our main window when we restore it from the task bar. This helps with layout issues if we start PicoTorrent in the task bar for example.