### PR TITLE
Rework how we build file trees

### DIFF
--- a/src/picotorrent/ui/dialogs/addtorrentdialog.cpp
+++ b/src/picotorrent/ui/dialogs/addtorrentdialog.cpp
@@ -344,7 +344,10 @@ void AddTorrentDialog::Load(size_t index)
         // Files
         m_filesModel->RebuildTree(params.ti);
         m_filesModel->UpdatePriorities(params.file_priorities);
-        m_filesView->Expand(m_filesModel->GetRootItem());
+
+        wxDataViewItemArray children;
+        m_filesModel->GetChildren(m_filesModel->GetRootItem(), children);
+        for (auto const& child : children) { m_filesView->Expand(child); }
     }
     else
     {

--- a/src/picotorrent/ui/dialogs/addtorrentdialog.cpp
+++ b/src/picotorrent/ui/dialogs/addtorrentdialog.cpp
@@ -357,14 +357,14 @@ void AddTorrentDialog::SetFilePriorities(wxDataViewItemArray& items, lt::downloa
     auto& param = m_params.at(m_torrents->GetSelection());
     auto fileIndices = m_filesModel->GetFileIndices(items);
 
-    for (int idx : fileIndices)
+    for (lt::file_index_t idx : fileIndices)
     {
-        if (param.file_priorities.size() <= idx)
+        if (param.file_priorities.size() <= static_cast<int>(idx))
         {
-            param.file_priorities.resize(size_t(idx) + 1, lt::default_priority);
+            param.file_priorities.resize(static_cast<int>(idx) + 1, lt::default_priority);
         }
 
-        param.file_priorities.at(idx) = prio;
+        param.file_priorities.at(static_cast<int>(idx)) = prio;
     }
 }
 
@@ -381,16 +381,17 @@ void AddTorrentDialog::ShowFileContextMenu(wxDataViewEvent& evt)
     auto& param = m_params.at(m_torrents->GetSelection());
     auto fileIndices = m_filesModel->GetFileIndices(items);
     auto firstPrio = param.file_priorities.size() > 0
-        ? param.file_priorities[fileIndices[0]]
+        ? param.file_priorities[static_cast<int>(fileIndices[0])]
         : lt::default_priority;
 
     auto allSamePrio = std::all_of(
         fileIndices.begin(),
         fileIndices.end(),
-        [&](int i)
+        [&](lt::file_index_t i)
         {
-            auto p = param.file_priorities.size() >= i + 1
-                ? param.file_priorities[i]
+            int i32 = static_cast<int>(i);
+            auto p = param.file_priorities.size() >= i32 + 1
+                ? param.file_priorities[i32]
                 : lt::default_priority;
             return firstPrio == p;
         });

--- a/src/picotorrent/ui/models/filestoragemodel.hpp
+++ b/src/picotorrent/ui/models/filestoragemodel.hpp
@@ -42,7 +42,7 @@ namespace Models
         unsigned int GetChildren(const wxDataViewItem &parent, wxDataViewItemArray &array) const wxOVERRIDE;
 
         void ClearNodes();
-        std::vector<int> GetFileIndices(wxDataViewItemArray&);
+        std::vector<libtorrent::file_index_t> GetFileIndices(wxDataViewItemArray&);
         wxDataViewItem GetRootItem();
         void RebuildTree(std::shared_ptr<const libtorrent::torrent_info> ti);
         void UpdatePriorities(const std::vector<libtorrent::download_priority_t>& priorities);
@@ -53,7 +53,7 @@ namespace Models
         {
             std::string name;
             int64_t size;
-            int index;
+            libtorrent::file_index_t index;
             libtorrent::download_priority_t priority;
             float progress;
 
@@ -61,12 +61,11 @@ namespace Models
             std::map<std::string, std::shared_ptr<Node>> children;
         };
 
-        void FillIndices(Node* node, std::vector<int>& indices);
+        void FillIndices(Node* node, std::vector<libtorrent::file_index_t>& indices);
         wxIcon GetIconForFile(std::string const& fileName) const;
 
-        wxIcon m_folderIcon;
         std::shared_ptr<Node> m_root;
-        std::map<int, std::shared_ptr<Node>> m_map;
+        std::map<libtorrent::file_index_t, std::shared_ptr<Node>> m_map;
         std::map<std::string, wxIcon> m_icons;
 
         std::function<void(wxDataViewItemArray&, libtorrent::download_priority_t)> m_priorityChangedCallback;

--- a/src/picotorrent/ui/torrentdetailsfilespanel.cpp
+++ b/src/picotorrent/ui/torrentdetailsfilespanel.cpp
@@ -55,7 +55,10 @@ void TorrentDetailsFilesPanel::Refresh(BitTorrent::TorrentHandle* torrent)
             m_torrentPrevFileCount = tf->num_files();
 
             m_filesModel->RebuildTree(tf);
-            m_fileList->Expand(m_filesModel->GetRootItem());
+
+            wxDataViewItemArray children;
+            m_filesModel->GetChildren(m_filesModel->GetRootItem(), children);
+            for (auto const& child : children) { m_fileList->Expand(child); }
         }
 
         std::vector<int64_t> progress;

--- a/src/picotorrent/ui/torrentdetailsfilespanel.cpp
+++ b/src/picotorrent/ui/torrentdetailsfilespanel.cpp
@@ -88,16 +88,17 @@ void TorrentDetailsFilesPanel::ShowFileContextMenu(wxCommandEvent& evt)
     auto priorities = m_torrent->GetFilePriorities();
     auto fileIndices = m_filesModel->GetFileIndices(items);
     auto firstPrio = priorities.size() > 0
-        ? priorities[fileIndices[0]]
+        ? priorities[static_cast<int>(fileIndices[0])]
         : lt::default_priority;
 
     auto allSamePrio = std::all_of(
         fileIndices.begin(),
         fileIndices.end(),
-        [&](int i)
+        [&](lt::file_index_t i)
         {
-            auto p = priorities.size() >= i + size_t(1)
-                ? priorities[i]
+            int i32 = static_cast<int>(i);
+            auto p = priorities.size() >= i32 + size_t(1)
+                ? priorities[i32]
                 : lt::default_priority;
             return firstPrio == p;
         });
@@ -121,14 +122,15 @@ void TorrentDetailsFilesPanel::ShowFileContextMenu(wxCommandEvent& evt)
         {
             auto set = [&fileIndices, &priorities](lt::download_priority_t p)
             {
-                for (int idx : fileIndices)
+                for (lt::file_index_t idx : fileIndices)
                 {
-                    if (priorities.size() <= idx)
+                    int i32 = static_cast<int>(idx);
+                    if (priorities.size() <= i32)
                     {
-                        priorities.resize(size_t(idx) + 1, lt::default_priority);
+                        priorities.resize(size_t(i32) + 1, lt::default_priority);
                     }
 
-                    priorities.at(idx) = p;
+                    priorities.at(i32) = p;
                 }
             };
 


### PR DESCRIPTION
This fixes an issue in how the file storage tree is built. It crashed on torrents which had a folder with a file with the same name. Inspired by the corresponding function in qBittorrent - I tip my fedora in their direction 🎩 