### PR TITLE
Fix an issue with preloading magnet links

### DIFF
--- a/src/picotorrent/bittorrent/session.hpp
+++ b/src/picotorrent/bittorrent/session.hpp
@@ -88,6 +88,7 @@ namespace BitTorrent
 
     private:
         bool IsSearching(libtorrent::info_hash_t hash);
+        bool IsSearching(libtorrent::info_hash_t hash, libtorrent::info_hash_t& result);
         void LoadTorrents();
         void OnAlert();
         void PauseAfterRecheck(TorrentHandle*);


### PR DESCRIPTION
Fixes a few issues with preloading magnet links. Also ninja-fixes the outgoing interfaces (which cannot bind to 0.0.0.0 or [::]).