### PR TITLE
Better handling of Unicode, both in database and text inputs

### DIFF
--- a/src/picotorrent/core/configuration.hpp
+++ b/src/picotorrent/core/configuration.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include <loguru.hpp>
 #include <nlohmann/json.hpp>
 
 namespace pt
@@ -61,7 +62,17 @@ namespace Core
             {
                 return std::nullopt;
             }
-            return nlohmann::json::parse(val).get<T>();
+
+            try
+            {
+                return nlohmann::json::parse(val).get<T>();
+            }
+            catch (nlohmann::json::exception const& ex)
+            {
+                LOG_F(WARNING, "Failed to parse setting %s: %s (%s)", key.c_str(), val.c_str(), ex.what());
+            }
+
+            return std::nullopt;
         }
 
         template<typename T>

--- a/src/picotorrent/core/database.cpp
+++ b/src/picotorrent/core/database.cpp
@@ -57,7 +57,12 @@ void Database::Statement::Bind(int idx, int value)
 
 void Database::Statement::Bind(int idx, std::string const& value)
 {
-    sqlite3_bind_text(m_stmt, idx, value.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(
+        m_stmt,
+        idx,
+        value.c_str(),
+        value.size(),
+        SQLITE_TRANSIENT);
 }
 
 void Database::Statement::Bind(int idx, std::vector<char> const& value)
@@ -117,7 +122,9 @@ std::string Database::Statement::GetString(int idx)
         return std::string();
     }
 
-    return reinterpret_cast<const char*>(res);
+    return std::string(
+        reinterpret_cast<const char*>(res),
+        sqlite3_column_bytes(m_stmt, idx));
 }
 
 bool Database::Statement::Read()

--- a/src/picotorrent/ui/dialogs/preferencesdownloadspage.cpp
+++ b/src/picotorrent/ui/dialogs/preferencesdownloadspage.cpp
@@ -1,6 +1,7 @@
 #include "preferencesdownloadspage.hpp"
 
 #include "../../core/configuration.hpp"
+#include "../../core/utils.hpp"
 #include "../translator.hpp"
 
 #include <wx/filepicker.h>
@@ -118,7 +119,7 @@ PreferencesDownloadsPage::PreferencesDownloadsPage(wxWindow* parent, std::shared
     });
 
     m_moveCompletedEnabled->SetValue(cfg->Get<bool>("move_completed_downloads").value());
-    m_moveCompletedPathCtrl->SetPath(wxString::FromUTF8(cfg->Get<std::string>("move_completed_downloads_path").value_or("")));
+    m_moveCompletedPathCtrl->SetPath(Utils::toStdWString(cfg->Get<std::string>("move_completed_downloads_path").value_or("")));
     m_moveCompletedOnlyFromDefault->SetValue(cfg->Get<bool>("move_completed_downloads_from_default_only").value());
 
     m_moveCompletedPathCtrl->Enable(m_moveCompletedEnabled->IsChecked());
@@ -144,7 +145,7 @@ void PreferencesDownloadsPage::Save()
     // Move
     m_cfg->Set("move_completed_downloads", m_moveCompletedEnabled->IsChecked());
     m_cfg->Set("move_completed_downloads_from_default_only", m_moveCompletedOnlyFromDefault->IsChecked());
-    m_cfg->Set("move_completed_downloads_path", m_moveCompletedPathCtrl->GetPath().ToStdString());
+    m_cfg->Set("move_completed_downloads_path", Utils::toStdString(m_moveCompletedPathCtrl->GetPath().ToStdWstring()));
 
     // Active limits
     long activeLimit = 0;

--- a/src/picotorrent/ui/torrentcontextmenu.cpp
+++ b/src/picotorrent/ui/torrentcontextmenu.cpp
@@ -115,7 +115,9 @@ TorrentContextMenu::TorrentContextMenu(wxWindow* parent, std::vector<BitTorrent:
 
             for (auto torrent : selectedTorrents)
             {
-                torrent->MoveStorage(dlg.GetPath().ToStdString());
+                torrent->MoveStorage(
+                    Utils::toStdString(
+                        dlg.GetPath().ToStdWstring()));
             }
         },
         TorrentContextMenu::ptID_MOVE);


### PR DESCRIPTION
Behave better when inputing Unicode paths for the move torrent path, and also when reading/writing strings to the database.