### PR TITLE
Add timer to save resume data

### DIFF
--- a/res/dbmigrations/20200925235912_save_resume_data_interval.sql
+++ b/res/dbmigrations/20200925235912_save_resume_data_interval.sql
@@ -1,0 +1,2 @@
+INSERT INTO setting (key, value, default_value)
+VALUES ('save_resume_data_interval', NULL, 300);

--- a/src/picotorrent/bittorrent/session.hpp
+++ b/src/picotorrent/bittorrent/session.hpp
@@ -87,10 +87,17 @@ namespace BitTorrent
         void RemoveTorrent(TorrentHandle* handle, libtorrent::remove_flags_t flags = {});
 
     private:
+        enum
+        {
+            ptID_TIMER_SESSION = 1000,
+            ptID_TIMER_RESUME_DATA
+        };
+
         bool IsSearching(libtorrent::info_hash_t hash);
         bool IsSearching(libtorrent::info_hash_t hash, libtorrent::info_hash_t& result);
         void LoadTorrents();
         void OnAlert();
+        void OnSaveResumeDataTimer(wxTimerEvent&);
         void PauseAfterRecheck(TorrentHandle*);
         void RemoveMetadataHandle(libtorrent::info_hash_t hash);
         void SaveState();
@@ -99,6 +106,7 @@ namespace BitTorrent
 
         wxEvtHandler* m_parent;
         wxTimer* m_timer;
+        wxTimer* m_resumeDataTimer;
         
         std::unique_ptr<libtorrent::session> m_session;
         std::shared_ptr<Core::Database> m_db;

--- a/src/picotorrent/resources.rc
+++ b/src/picotorrent/resources.rc
@@ -19,6 +19,7 @@ AppIcon ICON "..\\..\\res\\app.ico"
 20200823145617_insert_tracker_settings          DBMIGRATION "..\\..\\res\\dbmigrations\\20200823145617_insert_tracker_settings.sql"
 20200912230012_enhance_setting_table            DBMIGRATION "..\\..\\res\\dbmigrations\\20200912230012_enhance_setting_table.sql"
 20200916213321_insert_locale_name_setting       DBMIGRATION "..\\..\\res\\dbmigrations\\20200916213321_insert_locale_name_setting.sql"
+20200925235912_save_resume_data_interval        DBMIGRATION "..\\..\\res\\dbmigrations\\20200925235912_save_resume_data_interval.sql"
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION        VER_FILE_VERSION

--- a/src/picotorrent/ui/dialogs/preferencesadvancedpage.cpp
+++ b/src/picotorrent/ui/dialogs/preferencesadvancedpage.cpp
@@ -43,6 +43,12 @@ static std::map<std::string, std::map<std::string, Property>> properties =
             MAKE_PROP(Bool, Bool,    bool, "libtorrent.anonymous_mode", "anonymous_mode", "When set to true, the client tries to hide its identity to a certain degree. The user-agent will be reset to an empty string (except for private torrents). Trackers will only be used if they are using a proxy server. The listen sockets are closed, and incoming connections will only be accepted through a SOCKS5 or I2P proxy (if a peer proxy is set up and is run on the same machine as the tracker proxy). Since no incoming connections are accepted, NAT-PMP, UPnP, DHT and local peer discovery are all turned off when this setting is enabled. If you're using I2P, it might make sense to enable anonymous mode as well."),
             MAKE_PROP(Int,  Integer, int,  "libtorrent.stop_tracker_timeout", "stop_tracker_timeout", "The number of seconds to wait when sending a stopped message before considering a tracker to have timed out. This is usually shorter, to make the client quit faster. If the value is set to 0, the connections to trackers with the stopped event are suppressed."),
         }
+    },
+    {
+        "PicoTorrent",
+        {
+            MAKE_PROP(Int,  Integer, int,  "save_resume_data_interval", "save_resume_data_interval", "The interval (in seconds) between checks to save resume data for torrents. Saving resume data will help keep a current state if (for example) the application exits unexpectedly.")
+        }
     }
 };
 


### PR DESCRIPTION
Add a timer which saves torrents resume data at a configured interval (5 mins default). I'm hoping this will keep a more up to date state if PicoTorrent crashes.