### PR TITLE
[WIP] RSS monitor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,9 @@ add_executable(
     src/picotorrent/ipc/applicationoptionsconnection
     src/picotorrent/ipc/server
 
+    # RSS
+    src/picotorrent/rss/feedmanager
+
     # Dialogs
     src/picotorrent/ui/dialogs/aboutdialog
     src/picotorrent/ui/dialogs/addmagnetlinkdialog
@@ -178,6 +181,7 @@ add_executable(
     src/picotorrent/ui/dialogs/preferencesdownloadspage
     src/picotorrent/ui/dialogs/preferencesgeneralpage
     src/picotorrent/ui/dialogs/preferencesproxypage
+    src/picotorrent/ui/dialogs/preferencesrsspage
 
     # Models
     src/picotorrent/ui/models/filestoragemodel
@@ -241,7 +245,7 @@ target_link_libraries(
     PRIVATE
 
     # wxWidgets
-    core base propgrid
+    core base propgrid xml
 
     # Windows
     Comctl32

--- a/res/dbmigrations/20200927003412_rss_tables.sql
+++ b/res/dbmigrations/20200927003412_rss_tables.sql
@@ -1,0 +1,17 @@
+CREATE TABLE rss_feed (
+    id INTEGER PRIMARY KEY,
+    url TEXT NOT NULL UNIQUE,
+    name TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER
+);
+
+CREATE TABLE rss_feed_filter (
+    id INTEGER PRIMARY KEY,
+    feed_id INTEGER NOT NULL,
+    is_regex INTEGER NOT NULL,
+    include_filter TEXT,
+    exclude_filter TEXT,
+
+    FOREIGN KEY(feed_id) REFERENCES rss_feed(id)
+);

--- a/src/picotorrent/resources.rc
+++ b/src/picotorrent/resources.rc
@@ -20,6 +20,7 @@ AppIcon ICON "..\\..\\res\\app.ico"
 20200912230012_enhance_setting_table            DBMIGRATION "..\\..\\res\\dbmigrations\\20200912230012_enhance_setting_table.sql"
 20200916213321_insert_locale_name_setting       DBMIGRATION "..\\..\\res\\dbmigrations\\20200916213321_insert_locale_name_setting.sql"
 20200925235912_save_resume_data_interval        DBMIGRATION "..\\..\\res\\dbmigrations\\20200925235912_save_resume_data_interval.sql"
+20200927003412_rss_tables                       DBMIGRATION "..\\..\\res\\dbmigrations\\20200927003412_rss_tables.sql"
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION        VER_FILE_VERSION

--- a/src/picotorrent/rss/feedmanager.cpp
+++ b/src/picotorrent/rss/feedmanager.cpp
@@ -1,0 +1,17 @@
+#include "feedmanager.hpp"
+
+#include <wx/sstream.h>
+#include <wx/xml/xml.h>
+
+#include "../http/httpclient.hpp"
+
+using pt::RSS::FeedManager;
+
+FeedManager::FeedManager()
+    : m_httpClient(std::make_unique<Http::HttpClient>())
+{
+}
+
+FeedManager::~FeedManager()
+{
+}

--- a/src/picotorrent/rss/feedmanager.hpp
+++ b/src/picotorrent/rss/feedmanager.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include <memory>
+
+namespace pt::Http { class HttpClient; }
+
+namespace pt::RSS
+{
+    class FeedManager : public wxEvtHandler
+    {
+    public:
+        FeedManager();
+        virtual ~FeedManager();
+
+    private:
+        std::unique_ptr<Http::HttpClient> m_httpClient;
+    };
+}

--- a/src/picotorrent/ui/dialogs/preferencesdialog.cpp
+++ b/src/picotorrent/ui/dialogs/preferencesdialog.cpp
@@ -16,6 +16,7 @@
 #include "preferencesdownloadspage.hpp"
 #include "preferencesgeneralpage.hpp"
 #include "preferencesproxypage.hpp"
+#include "preferencesrsspage.hpp"
 #include "../translator.hpp"
 
 using pt::UI::Dialogs::PreferencesDialog;
@@ -27,6 +28,7 @@ PreferencesDialog::PreferencesDialog(wxWindow* parent, std::shared_ptr<Core::Con
     m_downloads(new PreferencesDownloadsPage(m_book, cfg)),
     m_connection(new PreferencesConnectionPage(m_book, cfg)),
     m_proxy(new PreferencesProxyPage(m_book, cfg)),
+    m_rss(new PreferencesRssPage(m_book, cfg)),
     m_advanced(new PreferencesAdvancedPage(m_book, cfg)),
     m_wantsRestart(false)
 {
@@ -35,6 +37,7 @@ PreferencesDialog::PreferencesDialog(wxWindow* parent, std::shared_ptr<Core::Con
     m_list->Append(i18n("downloads"));
     m_list->Append(i18n("connection"));
     m_list->Append(i18n("proxy"));
+    m_list->Append(i18n("rss"));
     m_list->Append(i18n("advanced"));
     m_list->Select(0);
 
@@ -42,6 +45,7 @@ PreferencesDialog::PreferencesDialog(wxWindow* parent, std::shared_ptr<Core::Con
     m_book->AddPage(m_downloads, wxEmptyString, false);
     m_book->AddPage(m_connection, wxEmptyString, false);
     m_book->AddPage(m_proxy, wxEmptyString, false);
+    m_book->AddPage(m_rss, wxEmptyString, false);
     m_book->AddPage(m_advanced, wxEmptyString, false);
 
     m_mainSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -118,6 +122,11 @@ void PreferencesDialog::OnOk(wxCommandEvent& evt)
         return;
     }
 
+    if (!m_rss->IsValid())
+    {
+        return;
+    }
+
     if (!m_advanced->IsValid())
     {
         return;
@@ -129,6 +138,7 @@ void PreferencesDialog::OnOk(wxCommandEvent& evt)
     m_downloads->Save();
     m_connection->Save(&restartRequired);
     m_proxy->Save();
+    m_rss->Save();
     m_advanced->Save();
 
     if (restartRequired)

--- a/src/picotorrent/ui/dialogs/preferencesdialog.hpp
+++ b/src/picotorrent/ui/dialogs/preferencesdialog.hpp
@@ -10,21 +10,16 @@
 class wxBookCtrlEvent;
 class wxSimplebook;
 
-namespace pt
-{
-namespace Core
-{
-    class Configuration;
-}
-namespace UI
-{
-namespace Dialogs
+namespace pt::Core { class Configuration; }
+
+namespace pt::UI::Dialogs
 {
     class PreferencesAdvancedPage;
     class PreferencesConnectionPage;
     class PreferencesDownloadsPage;
     class PreferencesGeneralPage;
     class PreferencesProxyPage;
+    class PreferencesRssPage;
 
     class PreferencesDialog : public wxDialog
     {
@@ -52,8 +47,7 @@ namespace Dialogs
         PreferencesDownloadsPage* m_downloads;
         PreferencesConnectionPage* m_connection;
         PreferencesProxyPage* m_proxy;
+        PreferencesRssPage* m_rss;
         PreferencesAdvancedPage* m_advanced;
     };
-}
-}
 }

--- a/src/picotorrent/ui/dialogs/preferencesrsspage.cpp
+++ b/src/picotorrent/ui/dialogs/preferencesrsspage.cpp
@@ -1,0 +1,21 @@
+#include "preferencesrsspage.hpp"
+
+using pt::UI::Dialogs::PreferencesRssPage;
+
+PreferencesRssPage::PreferencesRssPage(wxWindow* parent, std::shared_ptr<Core::Configuration> cfg)
+    : m_cfg(cfg)
+{
+}
+
+PreferencesRssPage::~PreferencesRssPage()
+{
+}
+
+bool PreferencesRssPage::IsValid()
+{
+    return true;
+}
+
+void PreferencesRssPage::Save()
+{
+}

--- a/src/picotorrent/ui/dialogs/preferencesrsspage.hpp
+++ b/src/picotorrent/ui/dialogs/preferencesrsspage.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include <memory>
+
+namespace pt::Core { class Configuration; }
+
+namespace pt::UI::Dialogs
+{
+    class PreferencesRssPage : public wxPanel
+    {
+    public:
+        PreferencesRssPage(wxWindow* parent, std::shared_ptr<Core::Configuration> cfg);
+        virtual ~PreferencesRssPage();
+
+        bool IsValid();
+        void Save();
+
+    private:
+        std::shared_ptr<Core::Configuration> m_cfg;
+    };
+}

--- a/src/picotorrent/ui/mainframe.cpp
+++ b/src/picotorrent/ui/mainframe.cpp
@@ -22,6 +22,7 @@
 #include "../core/environment.hpp"
 #include "../core/utils.hpp"
 #include "../ipc/server.hpp"
+#include "../rss/feedmanager.hpp"
 #include "dialogs/aboutdialog.hpp"
 #include "dialogs/addmagnetlinkdialog.hpp"
 #include "dialogs/addtorrentdialog.hpp"
@@ -46,6 +47,7 @@ MainFrame::MainFrame(std::shared_ptr<Core::Environment> env, std::shared_ptr<Cor
     m_env(env),
     m_db(db),
     m_cfg(cfg),
+    m_feedManager(std::make_unique<RSS::FeedManager>()),
     m_session(new BitTorrent::Session(this, db, cfg, env)),
     m_splitter(new wxSplitterWindow(this, ptID_MAIN_SPLITTER)),
     m_statusBar(new StatusBar(this)),

--- a/src/picotorrent/ui/mainframe.hpp
+++ b/src/picotorrent/ui/mainframe.hpp
@@ -14,9 +14,10 @@
 class wxSplitterWindow;
 class wxTaskBarIconEvent;
 
+namespace pt::RSS { class FeedManager; }
+
 namespace pt
 {
-    class UpdateChecker;
 
 namespace BitTorrent
 {
@@ -84,6 +85,7 @@ namespace Models
         std::shared_ptr<Core::Database> m_db;
         std::shared_ptr<Core::Configuration> m_cfg;
         std::unique_ptr<IPC::Server> m_ipc;
+        std::unique_ptr<RSS::FeedManager> m_feedManager;
 
         wxMenu* m_viewMenu;
         wxMenu* m_filtersMenu;


### PR DESCRIPTION
Add a basic RSS monitor to PicoTorrent. It should support monitoring of one or more RSS feeds, with filters for each feed deciding what to add and what to ignore. When label support lands we should also be able to connect feeds with labels.