### PR TITLE
Add Translations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Build your desired configuration and architecture.
 ```
 
 
+## Translations
+
+PicoTorrent uses [Weblate](https://translate.picotorrent.org/) to handle the translation process. If you want to help, feel free to signup and give your contribution.
+
+
 ## License
 
 Copyright (c) Viktor Elofsson and contributors. PicoTorrent is provided


### PR DESCRIPTION
Added a new section to the README.md file to better explain the translation process used by PicoTorrent as per discussion on #911.