### PR TITLE
Use the Common Item Dialog to support more files being opened

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,9 @@ add_executable(
     src/picotorrent/ui/torrentfilelistview
     src/picotorrent/ui/torrentlistview
     src/picotorrent/ui/translator
+
+    # Win32 specific stuff
+    src/picotorrent/ui/win32/openfiledialog
 )
 
 target_compile_definitions(
@@ -249,6 +252,7 @@ target_link_libraries(
     crypt32
     iphlpapi
     legacy_stdio_definitions
+    propsys
     shlwapi
     wininet
     winhttp

--- a/src/picotorrent/ui/win32/openfiledialog.cpp
+++ b/src/picotorrent/ui/win32/openfiledialog.cpp
@@ -1,0 +1,104 @@
+#include "openfiledialog.hpp"
+
+#define STRICT_TYPED_ITEMIDS
+#include <shlobj.h>
+#include <objbase.h>      // For COM headers
+#include <shobjidl.h>     // for IFileDialogEvents and IFileDialogControlEvents
+#include <shlwapi.h>
+#include <knownfolders.h> // for KnownFolder APIs/datatypes/function headers
+#include <propvarutil.h>  // for PROPVAR-related functions
+#include <propkey.h>      // for the Property key APIs/datatypes
+#include <propidl.h>      // for the Property System APIs
+#include <strsafe.h>      // for StringCchPrintfW
+#include <shtypes.h>      // for COMDLG_FILTERSPEC
+
+#include <string>
+
+#include "../../core/utils.hpp"
+
+using pt::UI::Win32::OpenFileDialog;
+
+OpenFileDialog::OpenFileDialog()
+    : m_wrappedDialog(nullptr)
+{
+    if (!SUCCEEDED(CoCreateInstance(CLSID_FileOpenDialog,
+        NULL,
+        CLSCTX_INPROC_SERVER,
+        IID_PPV_ARGS(&m_wrappedDialog))))
+    {
+        throw std::exception();
+    }
+}
+
+OpenFileDialog::~OpenFileDialog()
+{
+    m_wrappedDialog->Release();
+}
+
+void OpenFileDialog::GetFiles(std::vector<std::string>& files)
+{
+    IShellItemArray* results = nullptr;
+
+    if (!SUCCEEDED(m_wrappedDialog->GetResults(&results))
+        || results == nullptr)
+    {
+        return;
+    }
+
+    DWORD count;
+    results->GetCount(&count);
+
+    files.reserve(count);
+
+    for (size_t i = 0; i < count; i++)
+    {
+        PWSTR path = nullptr;
+
+        IShellItem* item;
+        results->GetItemAt(i, &item);
+        
+        if (SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &path))
+            && path != nullptr)
+        {
+            files.push_back(
+                Utils::toStdString(path));
+            CoTaskMemFree(path);
+        }
+
+        item->Release();
+    }
+
+    results->Release();
+}
+
+void OpenFileDialog::SetFileTypes(std::vector<std::tuple<std::wstring, std::wstring>> const& types)
+{
+    std::vector<COMDLG_FILTERSPEC> spec;
+
+    for (auto const& t : types)
+    {
+        spec.push_back({
+                std::get<0>(t).c_str(),
+                std::get<1>(t).c_str() });
+    }
+
+    m_wrappedDialog->SetFileTypes(spec.size(), spec.data());
+}
+
+void OpenFileDialog::SetOption(OpenFileDialog::Option option)
+{
+    DWORD dwOptions;
+    m_wrappedDialog->GetOptions(&dwOptions);
+    if (option == Option::Multi) { dwOptions |= FOS_ALLOWMULTISELECT; }
+    m_wrappedDialog->SetOptions(dwOptions);
+}
+
+void OpenFileDialog::SetTitle(std::wstring const& title)
+{
+    m_wrappedDialog->SetTitle(title.c_str());
+}
+
+void OpenFileDialog::Show(wxWindow* parent)
+{
+    m_wrappedDialog->Show(parent->GetHWND());
+}

--- a/src/picotorrent/ui/win32/openfiledialog.hpp
+++ b/src/picotorrent/ui/win32/openfiledialog.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <wx/wxprec.h>
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+struct IFileOpenDialog;
+
+namespace pt::UI::Win32
+{
+    class OpenFileDialog
+    {
+    public:
+        enum class Option
+        {
+            Multi
+        };
+
+        OpenFileDialog();
+        ~OpenFileDialog();
+
+        void GetFiles(std::vector<std::string>& files);
+
+        void SetFileTypes(std::vector<std::tuple<std::wstring, std::wstring>> const& types);
+        void SetOption(Option opt);
+        void SetTitle(std::wstring const& title);
+        void Show(wxWindow* parent);
+
+    private:
+        IFileOpenDialog* m_wrappedDialog;
+    };
+}


### PR DESCRIPTION
Replace the wxWidgets dialog with our own based on the Common Item Dialog API in Windows. Makes it possible to select thousands of torrents when opening files.