### PR TITLE
Update wxWidgets, fix splitter flickering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -234,7 +234,7 @@ target_link_libraries(
     ${Boost_LIBRARIES}
 
     # wxWidgets
-    core base propgrid
+    wxcore wxbase wxpropgrid
 
     # Windows
     Comctl32

--- a/src/picotorrent/ui/mainframe.cpp
+++ b/src/picotorrent/ui/mainframe.cpp
@@ -61,6 +61,8 @@ MainFrame::MainFrame(std::shared_ptr<Core::Environment> env, std::shared_ptr<Cor
     m_menuItemFilters(nullptr),
     m_ipc(std::make_unique<IPC::Server>(this))
 {
+    m_splitter->SetWindowStyleFlag(
+        m_splitter->GetWindowStyleFlag() | wxSP_LIVE_UPDATE);
     m_splitter->SetMinimumPaneSize(10);
     m_splitter->SetSashGravity(0.5);
     m_splitter->SplitHorizontally(


### PR DESCRIPTION
This will update wxWidgets to 3.1.4 and also fix the issue with the splitter flickering when moving it.