### PR TITLE
Torrent overview: add user-defined column count, optional piece progress

### DIFF
--- a/res/dbmigrations/20201027213145_insert_overview_columns.sql
+++ b/res/dbmigrations/20201027213145_insert_overview_columns.sql
@@ -1,0 +1,4 @@
+INSERT INTO setting (key, value, default_value)
+VALUES
+    ('ui.torrent_overview.columns', NULL, 2),
+    ('ui.torrent_overview.show_piece_progress', NULL, 'true');

--- a/src/picotorrent/resources.rc
+++ b/src/picotorrent/resources.rc
@@ -21,6 +21,7 @@ AppIcon ICON "..\\..\\res\\app.ico"
 20200916213321_insert_locale_name_setting       DBMIGRATION "..\\..\\res\\dbmigrations\\20200916213321_insert_locale_name_setting.sql"
 20200919221011_create_label_table               DBMIGRATION "..\\..\\res\\dbmigrations\\20200919221011_create_label_table.sql"
 20200925235912_save_resume_data_interval        DBMIGRATION "..\\..\\res\\dbmigrations\\20200925235912_save_resume_data_interval.sql"
+20201027213145_insert_overview_columns          DBMIGRATION "..\\..\\res\\dbmigrations\\20201027213145_insert_overview_columns.sql"
 
 VS_VERSION_INFO VERSIONINFO
  FILEVERSION        VER_FILE_VERSION

--- a/src/picotorrent/ui/dialogs/preferencesadvancedpage.cpp
+++ b/src/picotorrent/ui/dialogs/preferencesadvancedpage.cpp
@@ -47,7 +47,9 @@ static std::map<std::string, std::map<std::string, Property>> properties =
     {
         "PicoTorrent",
         {
-            MAKE_PROP(Int,  Integer, int,  "save_resume_data_interval", "save_resume_data_interval", "The interval (in seconds) between checks to save resume data for torrents. Saving resume data will help keep a current state if (for example) the application exits unexpectedly.")
+            MAKE_PROP(Int,  Integer, int,  "save_resume_data_interval",   "save_resume_data_interval", "The interval (in seconds) between checks to save resume data for torrents. Saving resume data will help keep a current state if (for example) the application exits unexpectedly."),
+            MAKE_PROP(Int,  Integer, int,  "ui.torrent_overview.columns", "torrent_overview_columns",  "The number of columns to show in the torrent overview panel."),
+            MAKE_PROP(Bool, Bool,    bool, "ui.torrent_overview.show_piece_progress", "torrent_overview_show_piece_progress",  "When set to true, show the piece progress bar in the torrent overview panel.")
         }
     }
 };

--- a/src/picotorrent/ui/mainframe.cpp
+++ b/src/picotorrent/ui/mainframe.cpp
@@ -54,7 +54,7 @@ MainFrame::MainFrame(std::shared_ptr<Core::Environment> env, std::shared_ptr<Cor
     m_splitter(new wxSplitterWindow(this, ptID_MAIN_SPLITTER)),
     m_statusBar(new StatusBar(this)),
     m_taskBarIcon(new TaskBarIcon(this)),
-    m_torrentDetails(new TorrentDetailsView(m_splitter, ptID_MAIN_TORRENT_DETAILS)),
+    m_torrentDetails(new TorrentDetailsView(m_splitter, ptID_MAIN_TORRENT_DETAILS, cfg)),
     m_torrentListModel(new Models::TorrentListModel()),
     m_torrentList(new TorrentListView(m_splitter, ptID_MAIN_TORRENT_LIST, m_torrentListModel)),
     m_torrentsCount(0),
@@ -751,6 +751,7 @@ void MainFrame::OnViewPreferences(wxCommandEvent&)
             m_taskBarIcon->Hide();
         }
 
+        m_torrentDetails->ReloadConfiguration();
         m_torrentListModel->SetBackgroundColorEnabled(
             m_cfg->Get<bool>("use_label_as_list_bgcolor").value());
 

--- a/src/picotorrent/ui/torrentdetailsoverviewpanel.hpp
+++ b/src/picotorrent/ui/torrentdetailsoverviewpanel.hpp
@@ -5,6 +5,8 @@
 #include <wx/wx.h>
 #endif
 
+class wxFlexGridSizer;
+
 namespace pt::UI::Widgets { class PieceProgressBar; }
 
 namespace pt
@@ -18,12 +20,15 @@ namespace UI
     class TorrentDetailsOverviewPanel : public wxScrolledWindow
     {
     public:
-        TorrentDetailsOverviewPanel(wxWindow* parent, wxWindowID id);
+        TorrentDetailsOverviewPanel(wxWindow* parent, wxWindowID id, int cols = 2, bool showPieceProgress = true);
 
         void Refresh(BitTorrent::TorrentHandle* torrent);
         void Reset();
+        void UpdateView(int cols, bool showPieceProgress);
 
     private:
+        wxFlexGridSizer* m_sizer;
+        wxBoxSizer* m_mainSizer;
         Widgets::PieceProgressBar* m_pieceProgress;
         wxStaticText* m_name;
         wxStaticText* m_infoHash;

--- a/src/picotorrent/ui/torrentdetailsview.cpp
+++ b/src/picotorrent/ui/torrentdetailsview.cpp
@@ -3,6 +3,7 @@
 #include <wx/notebook.h>
 #include <wx/sizer.h>
 
+#include "../core/configuration.hpp"
 #include "torrentdetailsfilespanel.hpp"
 #include "torrentdetailsoverviewpanel.hpp"
 #include "torrentdetailspeerspanel.hpp"
@@ -11,8 +12,9 @@
 
 using pt::UI::TorrentDetailsView;
 
-TorrentDetailsView::TorrentDetailsView(wxWindow* parent, wxWindowID id)
+TorrentDetailsView::TorrentDetailsView(wxWindow* parent, wxWindowID id, std::shared_ptr<Core::Configuration> cfg)
     : wxNotebook(parent, id),
+    m_cfg(cfg),
     m_overview(new TorrentDetailsOverviewPanel(this, wxID_ANY)),
     m_files(new TorrentDetailsFilesPanel(this, wxID_ANY)),
     m_peers(new TorrentDetailsPeersPanel(this, wxID_ANY)),
@@ -22,6 +24,7 @@ TorrentDetailsView::TorrentDetailsView(wxWindow* parent, wxWindowID id)
     this->AddPage(m_files,    i18n("files"));
     this->AddPage(m_peers,    i18n("peers"));
     this->AddPage(m_trackers, i18n("trackers"));
+    this->ReloadConfiguration();
 }
 
 TorrentDetailsView::~TorrentDetailsView()
@@ -40,6 +43,16 @@ void TorrentDetailsView::Refresh(std::map<lt::info_hash_t, BitTorrent::TorrentHa
     m_files->Refresh(torrents.begin()->second);
     m_peers->Refresh(torrents.begin()->second);
     m_trackers->Refresh(torrents.begin()->second);
+}
+
+void TorrentDetailsView::ReloadConfiguration()
+{
+    auto showPieceProgress = m_cfg->Get<bool>("ui.torrent_overview.show_piece_progress");
+    auto cols = m_cfg->Get<int>("ui.torrent_overview.columns");
+
+    m_overview->UpdateView(
+        cols.value_or(2),
+        showPieceProgress.value_or(true));
 }
 
 void TorrentDetailsView::Reset()

--- a/src/picotorrent/ui/torrentdetailsview.hpp
+++ b/src/picotorrent/ui/torrentdetailsview.hpp
@@ -6,17 +6,15 @@
 #endif
 
 #include <map>
+#include <memory>
 
 #include <libtorrent/info_hash.hpp>
 #include <wx/notebook.h>
 
-namespace pt
-{
-namespace BitTorrent
-{
-    class TorrentHandle;
-}
-namespace UI
+namespace pt::BitTorrent { class TorrentHandle; }
+namespace pt::Core { class Configuration; }
+
+namespace pt::UI
 {
     class TorrentDetailsFilesPanel;
     class TorrentDetailsOverviewPanel;
@@ -26,17 +24,19 @@ namespace UI
     class TorrentDetailsView : public wxNotebook
     {
     public:
-        TorrentDetailsView(wxWindow* parent, wxWindowID id);
+        TorrentDetailsView(wxWindow* parent, wxWindowID id, std::shared_ptr<Core::Configuration> cfg);
         virtual ~TorrentDetailsView();
 
         void Refresh(std::map<libtorrent::info_hash_t, BitTorrent::TorrentHandle*> const& torrents);
+        void ReloadConfiguration();
         void Reset();
 
     private:
+        std::shared_ptr<Core::Configuration> m_cfg;
+
         TorrentDetailsOverviewPanel* m_overview;
         TorrentDetailsFilesPanel* m_files;
         TorrentDetailsPeersPanel* m_peers;
         TorrentDetailsTrackersPanel* m_trackers;
     };
-}
 }


### PR DESCRIPTION
The column count in the overview panel is now customizable from the advanced settings. Also, the piece progress bar can be toggled on or off from the advanced settings as well.

![image](https://user-images.githubusercontent.com/1491824/97345903-f8950000-188a-11eb-8f1e-c828d381f61f.png)

![image](https://user-images.githubusercontent.com/1491824/97345951-0e0a2a00-188b-11eb-9489-6d9334dda18a.png)
