### PR TITLE
Add missing string in UI

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -126,6 +126,7 @@
     "minimize_to_notification_area": "Minimize to notification area",
     "close_to_notification_area": "Close to notification area",
     "info_hash": "Info hash",
+    "leeches": "Leeches",
     "fails": "Fails",
     "force_recheck": "Force recheck",
     "availability": "Availability",


### PR DESCRIPTION
It is the `Leeches` column title in the `Trackers` tab of torrent details.