### PR TITLE
Destination path can be chosen for command line added files (#1098)

### DIFF
--- a/src/picotorrent/application.cpp
+++ b/src/picotorrent/application.cpp
@@ -39,9 +39,18 @@ Application::~Application()
 bool Application::OnCmdLineParsed(wxCmdLineParser& parser)
 {
     long waitForPid = -1;
+    wxString save_path = "";
+
     if (parser.Found("wait-for-pid", &waitForPid))
     {
         m_options.pid = waitForPid;
+    }
+
+    m_options.silent = parser.Found("silent");
+
+    if (parser.Found("save_path", &save_path))
+    {
+        m_options.save_path = Utils::toStdString(save_path.ToStdWstring());
     }
 
     for (size_t i = 0; i < parser.GetParamCount(); i++)
@@ -80,6 +89,7 @@ bool Application::OnInit()
     pt::CrashpadInitializer::Initialize(env);
 
     auto db = std::make_shared<pt::Core::Database>(env);
+
 
     if (!db->Migrate())
     {
@@ -122,7 +132,7 @@ bool Application::OnInit()
     m_persistence = std::make_unique<PersistenceManager>(db);
     wxPersistenceManager::Set(*m_persistence);
 
-    auto mainFrame = new UI::MainFrame(env, db, cfg);
+    auto mainFrame = new UI::MainFrame(env, db, cfg, m_options);
 
     std::for_each(
         m_plugins.begin(),
@@ -161,9 +171,7 @@ bool Application::OnInit()
         break;
     }
 
-    mainFrame->HandleParams(
-        m_options.files,
-        m_options.magnets);
+    mainFrame->HandleParams(m_options);
 
     return true;
 }
@@ -172,8 +180,10 @@ void Application::OnInitCmdLine(wxCmdLineParser& parser)
 {
     static const wxCmdLineEntryDesc cmdLineDesc[] =
     {
-        { wxCMD_LINE_OPTION, NULL, "wait-for-pid", NULL,     wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
-        { wxCMD_LINE_PARAM,  NULL, NULL,           "params", wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE },
+        { wxCMD_LINE_OPTION, NULL, "wait-for-pid",  NULL,   wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
+        { wxCMD_LINE_SWITCH, NULL, "silent",        NULL,   wxCMD_LINE_VAL_NONE ,  wxCMD_LINE_PARAM_OPTIONAL },
+        { wxCMD_LINE_OPTION, NULL, "save_path",     NULL,   wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
+        { wxCMD_LINE_PARAM,  NULL, NULL,           "params",wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE },
         { wxCMD_LINE_NONE }
     };
 
@@ -186,6 +196,8 @@ void Application::ActivateOtherInstance()
     json j;
     j["files"] = m_options.files;
     j["magnet_links"] = m_options.magnets;
+    j["silent"] = m_options.silent;
+    j["save_path"] = m_options.save_path;
 
     wxClient client;
     auto conn = client.MakeConnection(

--- a/src/picotorrent/application.cpp
+++ b/src/picotorrent/application.cpp
@@ -48,7 +48,7 @@ bool Application::OnCmdLineParsed(wxCmdLineParser& parser)
 
     m_options.silent = parser.Found("silent");
 
-    if (parser.Found("save_path", &save_path))
+    if (parser.Found("save-path", &save_path))
     {
         m_options.save_path = Utils::toStdString(save_path.ToStdWstring());
     }
@@ -182,7 +182,7 @@ void Application::OnInitCmdLine(wxCmdLineParser& parser)
     {
         { wxCMD_LINE_OPTION, NULL, "wait-for-pid",  NULL,   wxCMD_LINE_VAL_NUMBER, wxCMD_LINE_PARAM_OPTIONAL },
         { wxCMD_LINE_SWITCH, NULL, "silent",        NULL,   wxCMD_LINE_VAL_NONE ,  wxCMD_LINE_PARAM_OPTIONAL },
-        { wxCMD_LINE_OPTION, NULL, "save_path",     NULL,   wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
+        { wxCMD_LINE_OPTION, NULL, "save-path",     NULL,   wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
         { wxCMD_LINE_PARAM,  NULL, NULL,           "params",wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE },
         { wxCMD_LINE_NONE }
     };

--- a/src/picotorrent/application.hpp
+++ b/src/picotorrent/application.hpp
@@ -6,6 +6,8 @@
 #include <memory>
 #include <vector>
 
+#include "applicationoptions.hpp"
+
 class wxSingleInstanceChecker;
 
 namespace pt
@@ -28,18 +30,10 @@ namespace API
         virtual void OnInitCmdLine(wxCmdLineParser&) wxOVERRIDE;
 
     private:
-        struct Options
-        {
-            Options() : pid(-1) {}
-            long pid;
-            std::vector<std::string> files;
-            std::vector<std::string> magnets;
-        };
-
         void ActivateOtherInstance();
         void WaitForPreviousInstance(long pid);
 
-        Options m_options;
+        pt::CommandLineOptions m_options;
         std::vector<API::IPlugin*> m_plugins;
         std::unique_ptr<PersistenceManager> m_persistence;
         std::unique_ptr<wxSingleInstanceChecker> m_singleInstance;

--- a/src/picotorrent/applicationoptions.hpp
+++ b/src/picotorrent/applicationoptions.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace pt
+{
+    struct CommandLineOptions
+    {
+        CommandLineOptions() : pid(-1), silent(false) {}
+        long pid;
+        bool silent;
+        std::vector<std::string> files;
+        std::vector<std::string> magnets;
+        std::string save_path;
+    };
+}

--- a/src/picotorrent/applicationoptions.hpp
+++ b/src/picotorrent/applicationoptions.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
 
 namespace pt
 {

--- a/src/picotorrent/ipc/applicationoptionsconnection.cpp
+++ b/src/picotorrent/ipc/applicationoptionsconnection.cpp
@@ -4,10 +4,13 @@
 #include <nlohmann/json.hpp>
 #include <wx/taskbarbutton.h>
 
+#include "../applicationoptions.hpp"
 #include "../ui/mainframe.hpp"
 
 using json = nlohmann::json;
 using pt::IPC::ApplicationOptionsConnection;
+
+
 
 ApplicationOptionsConnection::ApplicationOptionsConnection(pt::UI::MainFrame* frame)
     : m_frame(frame)
@@ -21,10 +24,15 @@ bool ApplicationOptionsConnection::OnExecute(const wxString&, const void *data, 
     m_frame->GetEventHandler()->CallAfter([this, textData]()
         {
             json j;
+            pt::CommandLineOptions options;
 
             try
             {
                 j = json::parse(textData);
+                options.files = j["files"].get<std::vector<std::string>>();
+                options.magnets = j["magnet_links"].get<std::vector<std::string>>();
+                options.save_path = j["save_path"].get<std::string>();
+                options.silent = j["silent"].get<bool>();
             }
             catch (std::exception const& e)
             {
@@ -41,7 +49,7 @@ bool ApplicationOptionsConnection::OnExecute(const wxString&, const void *data, 
 
             m_frame->Raise();
             m_frame->Show();
-            m_frame->HandleParams(j["files"], j["magnet_links"]);
+            m_frame->HandleParams(options);
         });
 
     return true;

--- a/src/picotorrent/ui/dialogs/createtorrentdialog.cpp
+++ b/src/picotorrent/ui/dialogs/createtorrentdialog.cpp
@@ -1,6 +1,7 @@
 #include "createtorrentdialog.hpp"
 
 #include <filesystem>
+#include <fstream>
 
 #include <boost/log/trivial.hpp>
 #include <fmt/format.h>

--- a/src/picotorrent/ui/mainframe.cpp
+++ b/src/picotorrent/ui/mainframe.cpp
@@ -401,7 +401,7 @@ MainFrame::~MainFrame()
     delete m_taskBarIcon;
 }
 
-void MainFrame::AddTorrents(std::vector<lt::add_torrent_params>& params)
+void MainFrame::AddTorrents(std::vector<lt::add_torrent_params>& params, bool use_commandline_options)
 {
     bool didRemove = false;
 
@@ -447,7 +447,7 @@ void MainFrame::AddTorrents(std::vector<lt::add_torrent_params>& params)
         auto our = new BitTorrent::AddParams();
 
         p.flags |= lt::torrent_flags::duplicate_is_error;
-        if (!m_options.save_path.empty())
+        if ((m_options.save_path.empty() == false) && (use_commandline_options == true))
         {
             p.save_path = m_options.save_path;
         }
@@ -504,7 +504,7 @@ void MainFrame::AddTorrents(std::vector<lt::add_torrent_params>& params)
         }
     }
 
-    if (m_cfg->Get<bool>("skip_add_torrent_dialog").value() || m_options.silent)
+    if (m_cfg->Get<bool>("skip_add_torrent_dialog").value() || (m_options.silent && use_commandline_options))
     {
         for (lt::add_torrent_params& p : params)
         {
@@ -565,7 +565,7 @@ void MainFrame::HandleParams(pt::CommandLineOptions const& options)
         }
     }
 
-    AddTorrents(params);
+    AddTorrents(params, true);
 }
 
 void MainFrame::CheckDiskSpace(std::vector<pt::BitTorrent::TorrentHandle*> const& torrents)
@@ -744,7 +744,7 @@ void MainFrame::OnFileAddMagnetLink(wxCommandEvent&)
     if (dlg.ShowModal() == wxID_OK)
     {
         auto params = dlg.GetParams();
-        this->AddTorrents(params);
+        this->AddTorrents(params, false);
     }
 }
 
@@ -771,7 +771,7 @@ void MainFrame::OnFileAddTorrent(wxCommandEvent&)
 
     std::vector<lt::add_torrent_params> params;
     this->ParseTorrentFiles(params, files);
-    this->AddTorrents(params);
+    this->AddTorrents(params, false);
 }
 
 void MainFrame::OnFileCreateTorrent(wxCommandEvent&)

--- a/src/picotorrent/ui/mainframe.cpp
+++ b/src/picotorrent/ui/mainframe.cpp
@@ -424,10 +424,13 @@ void MainFrame::AddTorrents(std::vector<lt::add_torrent_params>& params, bool us
 
     if (didRemove)
     {
-        auto err = i18n("some_torrents_already_in_session");
-        if (params.empty()) err = i18n("all_torrents_already_in_session");
+        if (!m_options.silent || !use_commandline_options)
+        {
+            auto err = i18n("some_torrents_already_in_session");
+            if (params.empty()) err = i18n("all_torrents_already_in_session");
 
-        wxMessageBox(err, "PicoTorrent", wxOK, this);
+            wxMessageBox(err, "PicoTorrent", wxOK, this);
+        }
     }
 
     if (params.empty())
@@ -447,7 +450,7 @@ void MainFrame::AddTorrents(std::vector<lt::add_torrent_params>& params, bool us
         auto our = new BitTorrent::AddParams();
 
         p.flags |= lt::torrent_flags::duplicate_is_error;
-        if ((m_options.save_path.empty() == false) && (use_commandline_options == true))
+        if (!m_options.save_path.empty() && use_commandline_options)
         {
             p.save_path = m_options.save_path;
         }

--- a/src/picotorrent/ui/mainframe.hpp
+++ b/src/picotorrent/ui/mainframe.hpp
@@ -12,6 +12,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "../applicationoptions.hpp"
+
 class wxSplitterWindow;
 class wxTaskBarIconEvent;
 
@@ -54,10 +56,12 @@ namespace Models
         MainFrame(
             std::shared_ptr<Core::Environment> env,
             std::shared_ptr<Core::Database> db,
-            std::shared_ptr<Core::Configuration> cfg);
+            std::shared_ptr<Core::Configuration> cfg,
+            pt::CommandLineOptions const& options);
+
         virtual ~MainFrame();
 
-        void HandleParams(std::vector<std::string> const& files, std::vector<std::string> const& magnets);
+        void HandleParams(pt::CommandLineOptions const& options);
 
     private:
         wxMenuBar* CreateMainMenu();
@@ -93,6 +97,7 @@ namespace Models
         std::shared_ptr<Core::Database> m_db;
         std::shared_ptr<Core::Configuration> m_cfg;
         std::unique_ptr<IPC::Server> m_ipc;
+        pt::CommandLineOptions m_options;
 
         wxMenu* m_viewMenu;
         wxMenu* m_filtersMenu;

--- a/src/picotorrent/ui/mainframe.hpp
+++ b/src/picotorrent/ui/mainframe.hpp
@@ -66,7 +66,7 @@ namespace Models
     private:
         wxMenuBar* CreateMainMenu();
 
-        void AddTorrents(std::vector<libtorrent::add_torrent_params>& params);
+        void AddTorrents(std::vector<libtorrent::add_torrent_params>& params, bool use_commandline_options);
         void CheckDiskSpace(std::vector<BitTorrent::TorrentHandle*> const& updatedTorrents);
         void CreateFilterMenuItems();
         void CreateLabelMenuItems();


### PR DESCRIPTION
--save_path options allows to select the destination directory for the files.
--silent switch allows the files to be added without showing the add torrent dialog UI.