### PR TITLE
[WIP] Client/Server process separation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set(JSON_BuildTests OFF CACHE INTERNAL "")
 set(wxUSE_EXCEPTIONS OFF CACHE BOOL "" FORCE)
 # --------------------
 
-find_package(Boost REQUIRED COMPONENTS log)
+find_package(Boost REQUIRED COMPONENTS date_time log regex system)
 
 # vendor libs
 add_subdirectory(vendor/fmt)
@@ -124,6 +124,31 @@ target_link_libraries(
     PicoTorrent-coredb
     PRIVATE
     nlohmann_json::nlohmann_json
+    sqlite
+)
+
+add_executable(
+    PicoTorrentServer
+    src/server/main
+    src/server/http/http_listener
+    src/server/http/http_session
+)
+
+target_link_libraries(
+    PicoTorrentServer
+    PRIVATE
+
+    Boost::date_time
+    Boost::log
+    Boost::regex
+    Boost::system
+
+    # nlohmann-json
+    nlohmann_json::nlohmann_json
+
+    # Rasterbar-libtorrent
+    "torrent-rasterbar"
+
     sqlite
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,8 +130,14 @@ target_link_libraries(
 add_executable(
     PicoTorrentServer
     src/server/main
+    src/server/session_manager
+
+    # RPC commands
+    src/server/commands/torrents_add
+
     src/server/http/http_listener
     src/server/http/http_session
+    src/server/http/websocket_session
 )
 
 target_link_libraries(
@@ -158,10 +164,12 @@ add_executable(
 
     src/picotorrent/application
     src/picotorrent/buildinfo
+    src/picotorrent/clientwebsocket
     src/picotorrent/crashpadinitializer
     src/picotorrent/main
     src/picotorrent/persistencemanager
     src/picotorrent/resources.rc
+    src/picotorrent/serverprocess
 
     # API
     src/picotorrent/api/libpico

--- a/src/picotorrent/clientwebsocket.cpp
+++ b/src/picotorrent/clientwebsocket.cpp
@@ -1,0 +1,88 @@
+#include "clientwebsocket.hpp"
+
+#include <boost/asio.hpp>
+
+using pt::ClientWebSocket;
+
+ClientWebSocket::ClientWebSocket(boost::asio::io_context& io)
+    : m_websocket(boost::asio::make_strand(io))
+{
+}
+
+ClientWebSocket::~ClientWebSocket()
+{
+    OutputDebugStringA("WS: Destroyed\n");
+}
+
+void ClientWebSocket::Run()
+{
+    boost::beast::get_lowest_layer(m_websocket).expires_after(std::chrono::seconds(30));
+    boost::beast::get_lowest_layer(m_websocket).async_connect(
+        boost::asio::ip::tcp::endpoint{ boost::asio::ip::make_address("127.0.0.1"), 6545 },
+        boost::beast::bind_front_handler(
+            &ClientWebSocket::OnConnect,
+            shared_from_this()));
+}
+
+void ClientWebSocket::BeginRead()
+{
+    m_websocket.async_read(
+        m_buffer,
+        boost::beast::bind_front_handler(
+            &ClientWebSocket::OnRead,
+            shared_from_this()));
+}
+
+void ClientWebSocket::OnConnect(boost::beast::error_code ec)
+{
+    if (ec)
+    {
+        OutputDebugStringA(ec.message().c_str());
+        OutputDebugStringA("\n");
+        return;
+    }
+
+    boost::beast::get_lowest_layer(m_websocket).expires_never();
+    m_websocket.set_option(boost::beast::websocket::stream_base::timeout::suggested(boost::beast::role_type::client));
+
+    OutputDebugStringA("WS: Connected\n");
+
+    m_websocket.async_handshake("127.0.0.1:6545", "/api/ws",
+        boost::beast::bind_front_handler(
+            &ClientWebSocket::OnHandshake,
+            shared_from_this()));
+}
+
+void ClientWebSocket::OnHandshake(boost::beast::error_code ec)
+{
+    if (ec)
+    {
+        OutputDebugStringA(ec.message().c_str());
+        OutputDebugStringA("\n");
+        return;
+    }
+
+    OutputDebugStringA("WS: Handshake done\n");
+
+    BeginRead();
+}
+
+void ClientWebSocket::OnRead(boost::beast::error_code ec, size_t bytes_transferred)
+{
+    if (ec)
+    {
+        OutputDebugStringA(ec.message().c_str());
+        OutputDebugStringA("\n");
+        return;
+    }
+
+    OutputDebugStringA("WS: Read ");
+    OutputDebugStringA(std::to_string(bytes_transferred).c_str());
+    OutputDebugStringA(" bytes\n");
+
+    OutputDebugStringA("WS: ");
+    OutputDebugStringA(boost::beast::buffers_to_string(m_buffer.data()).c_str());
+    OutputDebugStringA("\n");
+
+    BeginRead();
+}

--- a/src/picotorrent/clientwebsocket.hpp
+++ b/src/picotorrent/clientwebsocket.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <boost/beast.hpp>
+#include <memory>
+
+namespace pt
+{
+    class ClientWebSocket : public std::enable_shared_from_this<ClientWebSocket>
+    {
+    public:
+        ClientWebSocket(boost::asio::io_context& io);
+        ~ClientWebSocket();
+
+        void Run();
+
+    private:
+        void BeginRead();
+        void OnConnect(boost::beast::error_code ec);
+        void OnHandshake(boost::beast::error_code ec);
+        void OnRead(boost::beast::error_code ec, size_t bytes_transferred);
+
+        boost::beast::websocket::stream<boost::beast::tcp_stream> m_websocket;
+        boost::beast::flat_buffer m_buffer;
+    };
+}

--- a/src/picotorrent/serverprocess.cpp
+++ b/src/picotorrent/serverprocess.cpp
@@ -1,0 +1,159 @@
+#include "serverprocess.hpp"
+
+#include <boost/beast.hpp>
+#include <boost/process.hpp>
+#include <boost/process/windows.hpp>
+
+#include "clientwebsocket.hpp"
+
+using json = nlohmann::json;
+using pt::ServerProcess;
+
+class HttpClient : public std::enable_shared_from_this<HttpClient>
+{
+public:
+    HttpClient(boost::asio::io_context& io)
+        : m_stream(boost::asio::make_strand(io))
+    {
+    }
+
+    void Post(nlohmann::json& j)
+    {
+        m_req.version(11);
+        m_req.method(boost::beast::http::verb::post);
+        m_req.target("/api/jsonrpc");
+        m_req.set(boost::beast::http::field::host, "localhost");
+        m_req.set(boost::beast::http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+        m_req.body() = j.dump();
+        m_req.prepare_payload();
+
+        m_stream.async_connect(
+            boost::asio::ip::tcp::endpoint{ boost::asio::ip::make_address("127.0.0.1"), 6545 },
+            boost::beast::bind_front_handler(
+                &HttpClient::OnConnect,
+                shared_from_this()));
+    }
+
+private:
+    void OnConnect(boost::beast::error_code ec)
+    {
+        if (ec)
+        {
+            OutputDebugStringA(ec.message().c_str());
+            OutputDebugStringA("\n");
+            return;
+        }
+
+        OutputDebugStringA("HttpClient: Connected\n");
+
+        // Set a timeout on the operation
+        m_stream.expires_after(std::chrono::seconds(30));
+
+        OutputDebugStringA(m_req.body().c_str());
+
+        // Send the HTTP request to the remote host
+        boost::beast::http::async_write(
+            m_stream,
+            m_req,
+            boost::beast::bind_front_handler(
+                &HttpClient::OnWrite,
+                shared_from_this()));
+    }
+
+    void OnWrite(boost::beast::error_code ec, std::size_t bytes_transferred)
+    {
+        if (ec)
+        {
+            OutputDebugStringA(ec.message().c_str());
+            OutputDebugStringA("\n");
+            return;
+        }
+
+        OutputDebugStringA("HttpClient: Wrote ");
+        OutputDebugStringA(std::to_string(bytes_transferred).c_str());
+        OutputDebugStringA(" byte(s)\n");
+
+        boost::beast::http::async_read(
+            m_stream,
+            m_buffer,
+            m_res,
+            boost::beast::bind_front_handler(
+                &HttpClient::OnRead,
+                shared_from_this()));
+    }
+
+    void OnRead(boost::beast::error_code ec, std::size_t bytes_transferred)
+    {
+        if (ec)
+        {
+            OutputDebugStringA(ec.message().c_str());
+            OutputDebugStringA("\n");
+            return;
+        }
+
+        OutputDebugStringA("HttpClient: Read ");
+        OutputDebugStringA(std::to_string(bytes_transferred).c_str());
+        OutputDebugStringA(" byte(s)\n");
+        OutputDebugStringA(m_res.body().c_str());
+        OutputDebugStringA("\n");
+    }
+
+    boost::beast::tcp_stream m_stream;
+    boost::beast::flat_buffer m_buffer;
+    boost::beast::http::request<boost::beast::http::string_body> m_req;
+    boost::beast::http::response<boost::beast::http::string_body> m_res;
+};
+
+ServerProcess::ServerProcess()
+{
+    m_thread = std::thread(std::bind(&ServerProcess::Run, this));
+}
+
+ServerProcess::~ServerProcess()
+{
+    m_io.stop();
+    m_thread.join();
+}
+
+void ServerProcess::RPC(std::string const& method, nlohmann::json& params)
+{
+    json rpc = {
+        { "method", method },
+        { "params", params }
+    };
+
+    std::make_shared<HttpClient>(m_io)->Post(rpc);
+}
+
+void ServerProcess::Run()
+{
+    std::vector<char> buf(4096);
+    boost::process::async_pipe ap(m_io);
+
+    boost::process::child child(
+        "",
+        //boost::process::windows::hide,
+        //boost::process::std_out > ap,
+        m_io,
+        boost::process::on_exit(
+            [](int code, std::error_code)
+            {
+                OutputDebugStringA(std::to_string(code).c_str());
+            }));
+
+    auto read = [=](const boost::system::error_code&, std::size_t size)
+    {
+        std::string out(buf.begin(), buf.begin() + size);
+        OutputDebugStringA(out.c_str());
+        OutputDebugStringA("\n");
+        //ap.async_read_some(boost::asio::buffer(buf), read);
+    };
+
+    ap.async_read_some(boost::asio::buffer(buf), read);
+
+    std::make_shared<ClientWebSocket>(m_io)->Run();
+
+    m_io.run();
+
+    child.terminate(); // TODO: shut down cleanly
+}

--- a/src/picotorrent/serverprocess.hpp
+++ b/src/picotorrent/serverprocess.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <thread>
+
+#include <boost/asio.hpp>
+#include <boost/beast.hpp>
+#include <nlohmann/json.hpp>
+
+namespace pt
+{
+    class ServerProcess
+    {
+    public:
+        ServerProcess();
+        ~ServerProcess();
+
+        void RPC(std::string const& cmd, nlohmann::json& json);
+
+    private:
+        void Run();
+
+        boost::asio::io_context m_io;
+        std::thread m_thread;
+    };
+}

--- a/src/picotorrent/ui/mainframe.cpp
+++ b/src/picotorrent/ui/mainframe.cpp
@@ -24,6 +24,7 @@
 #include "../core/environment.hpp"
 #include "../core/utils.hpp"
 #include "../ipc/server.hpp"
+#include "../serverprocess.hpp"
 #include "console.hpp"
 #include "dialogs/aboutdialog.hpp"
 #include "dialogs/addmagnetlinkdialog.hpp"
@@ -62,6 +63,8 @@ MainFrame::MainFrame(std::shared_ptr<Core::Environment> env, std::shared_ptr<Cor
     m_menuItemFilters(nullptr),
     m_ipc(std::make_unique<IPC::Server>(this))
 {
+    m_server = std::make_unique<ServerProcess>();
+
     m_console = new Console(this, wxID_ANY, m_torrentListModel);
 
     m_splitter->SetWindowStyleFlag(
@@ -432,6 +435,13 @@ void MainFrame::AddTorrents(std::vector<lt::add_torrent_params>& params)
         return;
     }
 
+    nlohmann::json j;
+    j["foo"] = "bar";
+
+    m_server->RPC("torrents.add", j);
+
+    return;/*
+
     std::vector<lt::info_hash_t> hashes;
 
     // Set up default values for all params
@@ -519,7 +529,7 @@ void MainFrame::AddTorrents(std::vector<lt::add_torrent_params>& params)
         m_addDialogs.insert(dlg);
     }
 
-    m_session->AddMetadataSearch(hashes);
+    m_session->AddMetadataSearch(hashes);*/
 }
 
 void MainFrame::HandleParams(std::vector<std::string> const& files, std::vector<std::string> const& magnets)

--- a/src/picotorrent/ui/mainframe.hpp
+++ b/src/picotorrent/ui/mainframe.hpp
@@ -19,6 +19,7 @@ namespace pt::UI::Dialogs { class AddTorrentDialog; }
 
 namespace pt
 {
+    class ServerProcess;
     class UpdateChecker;
 
 namespace BitTorrent
@@ -93,6 +94,7 @@ namespace Models
         std::shared_ptr<Core::Database> m_db;
         std::shared_ptr<Core::Configuration> m_cfg;
         std::unique_ptr<IPC::Server> m_ipc;
+        std::unique_ptr<ServerProcess> m_server;
 
         wxMenu* m_viewMenu;
         wxMenu* m_filtersMenu;

--- a/src/server/commands/command.hpp
+++ b/src/server/commands/command.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+namespace pt::commands
+{
+    class command
+    {
+    public:
+        virtual nlohmann::json execute(nlohmann::json const& params) = 0;
+    };
+}

--- a/src/server/commands/torrents_add.cpp
+++ b/src/server/commands/torrents_add.cpp
@@ -1,0 +1,16 @@
+#include "torrents_add.hpp"
+
+using json = nlohmann::json;
+using pt::commands::torrents_add_command;
+
+torrents_add_command::torrents_add_command(std::shared_ptr<pt::session_manager> const& session)
+    : m_session(session)
+{
+}
+
+json torrents_add_command::execute(json const& params)
+{
+    return {
+        { "ok", true }
+    };
+}

--- a/src/server/commands/torrents_add.hpp
+++ b/src/server/commands/torrents_add.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "command.hpp"
+
+namespace pt { class session_manager; }
+
+namespace pt::commands
+{
+    class torrents_add_command : public command
+    {
+    public:
+        torrents_add_command(std::shared_ptr<session_manager> const& session);
+        nlohmann::json execute(nlohmann::json const& params) override;
+
+    private:
+        std::shared_ptr<session_manager> m_session;
+    };
+}

--- a/src/server/http/http_listener.cpp
+++ b/src/server/http/http_listener.cpp
@@ -1,0 +1,62 @@
+#include "http_listener.hpp"
+
+#include <boost/beast.hpp>
+#include <boost/log/trivial.hpp>
+
+using pt::http::http_listener;
+
+http_listener::http_listener(
+    boost::asio::io_context& ioc,
+    boost::asio::ip::tcp::endpoint endpoint,
+    sqlite3* db,
+    std::shared_ptr<session_manager> const& session_manager,
+    std::shared_ptr<std::string const> const& doc_root)
+    : m_io(ioc)
+    , m_acceptor(boost::asio::make_strand(ioc))
+    , m_db(db)
+    , m_session_manager(session_manager)
+    , m_doc_root(doc_root)
+{
+    m_acceptor.open(endpoint.protocol());
+    m_acceptor.set_option(boost::asio::socket_base::reuse_address(true));
+    m_acceptor.bind(endpoint);
+    m_acceptor.listen(boost::asio::socket_base::max_listen_connections);
+}
+
+void http_listener::run()
+{
+    boost::asio::dispatch(
+        m_acceptor.get_executor(),
+        boost::beast::bind_front_handler(
+            &http_listener::do_accept,
+            shared_from_this()));
+}
+
+void http_listener::do_accept()
+{
+    m_acceptor.async_accept(
+        boost::asio::make_strand(m_io),
+        boost::beast::bind_front_handler(
+            &http_listener::on_accept,
+            shared_from_this()));
+}
+
+void http_listener::on_accept(boost::system::error_code ec, boost::asio::ip::tcp::socket socket)
+{
+    if(ec)
+    {
+        BOOST_LOG_TRIVIAL(error) << "Error when accepting HTTP client: " << ec.message();
+    }
+    else
+    {
+        BOOST_LOG_TRIVIAL(debug) << "Incoming HTTP client from " << socket.remote_endpoint();
+
+        /*std::make_shared<http_session>(
+            std::move(socket),
+            m_db,
+            m_session_manager,
+            m_doc_root)->run();*/
+    }
+
+    do_accept();
+}

--- a/src/server/http/http_listener.hpp
+++ b/src/server/http/http_listener.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <memory>
+
+#include <boost/asio.hpp>
+#include <sqlite3.h>
+
+namespace pt
+{
+    class session_manager;
+}
+
+namespace pt::http
+{
+    class http_listener : public std::enable_shared_from_this<http_listener>
+    {
+    public:
+        http_listener(
+            boost::asio::io_context& ioc,
+            boost::asio::ip::tcp::endpoint endpoint,
+            sqlite3* db,
+            std::shared_ptr<session_manager> const& session_manager,
+            std::shared_ptr<std::string const> const& doc_root);
+
+        void run();
+
+    private:
+        void do_accept();
+        void on_accept(boost::system::error_code ec, boost::asio::ip::tcp::socket socket);
+
+        boost::asio::io_context& m_io;
+        boost::asio::ip::tcp::acceptor m_acceptor;
+        sqlite3* m_db;
+        std::shared_ptr<session_manager> m_session_manager;
+        std::shared_ptr<std::string const> m_doc_root;
+    };
+}

--- a/src/server/http/http_listener.hpp
+++ b/src/server/http/http_listener.hpp
@@ -10,6 +10,11 @@ namespace pt
     class session_manager;
 }
 
+namespace pt::commands
+{
+    class command;
+}
+
 namespace pt::http
 {
     class http_listener : public std::enable_shared_from_this<http_listener>
@@ -22,6 +27,7 @@ namespace pt::http
             std::shared_ptr<session_manager> const& session_manager,
             std::shared_ptr<std::string const> const& doc_root);
 
+        std::map<std::string, std::shared_ptr<pt::commands::command>>& commands();
         void run();
 
     private:
@@ -33,5 +39,6 @@ namespace pt::http
         sqlite3* m_db;
         std::shared_ptr<session_manager> m_session_manager;
         std::shared_ptr<std::string const> m_doc_root;
+        std::shared_ptr<std::map<std::string, std::shared_ptr<pt::commands::command>>> m_commands;
     };
 }

--- a/src/server/http/http_session.cpp
+++ b/src/server/http/http_session.cpp
@@ -1,0 +1,234 @@
+#include "http_session.hpp"
+
+#include <boost/log/trivial.hpp>
+#include <nlohmann/json.hpp>
+
+#include "mime_type.hpp"
+#include "path_cat.hpp"
+#include "websocket_session.hpp"
+
+using json = nlohmann::json;
+
+http_session::http_session(
+    boost::asio::ip::tcp::socket&& socket,
+    sqlite3* db,
+    std::shared_ptr<session_manager> const& session_manager,
+    std::shared_ptr<std::string const> const& doc_root)
+    : stream_(std::move(socket))
+    , m_db(db)
+    , m_session_manager(session_manager)
+    , doc_root_(doc_root)
+    , queue_(*this)
+{
+}
+
+void http_session::run()
+{
+    // We need to be executing within a strand to perform async operations
+    // on the I/O objects in this session. Although not strictly necessary
+    // for single-threaded contexts, this example code is written to be
+    // thread-safe by default.
+    boost::asio::dispatch(
+        stream_.get_executor(),
+        boost::beast::bind_front_handler(
+            &http_session::do_read,
+            this->shared_from_this()));
+}
+
+void http_session::do_read()
+{
+    // Construct a new parser for each message
+    parser_.emplace();
+
+    // Apply a reasonable limit to the allowed size
+    // of the body in bytes to prevent abuse.
+    parser_->body_limit(10000000);
+
+    // Set the timeout.
+    stream_.expires_after(std::chrono::seconds(30));
+
+    // Read a request using the parser-oriented interface
+    boost::beast::http::async_read(
+        stream_,
+        buffer_,
+        *parser_,
+        boost::beast::bind_front_handler(
+            &http_session::on_read,
+            shared_from_this()));
+}
+
+void http_session::on_read(boost::beast::error_code ec, std::size_t bytes_transferred)
+{
+    namespace http = boost::beast::http;
+
+    boost::ignore_unused(bytes_transferred);
+
+    // This means they closed the connection
+    if(ec == http::error::end_of_stream)
+    {
+        return do_close();
+    }
+
+    if(ec)
+    {
+        BOOST_LOG_TRIVIAL(error) << "Error when reading HTTP request: " << ec.message();
+        return;
+    }
+
+    BOOST_LOG_TRIVIAL(debug) << "Incoming HTTP request to " << parser_->get().target();
+
+    if (parser_->get().target() == "/api/ws" && boost::beast::websocket::is_upgrade(parser_->get()))
+    {
+        std::make_shared<websocket_session>(
+            stream_.release_socket(),
+            m_db,
+            m_session_manager)->run(parser_->release());
+        return;
+    }
+
+    auto req = parser_->release();
+
+    auto const bad_request = [&req](boost::beast::string_view why)
+    {
+        http::response<http::string_body> res{http::status::bad_request, req.version()};
+        res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+        res.set(http::field::content_type, "text/plain");
+        res.keep_alive(req.keep_alive());
+        res.body() = std::string(why);
+        res.prepare_payload();
+        return res;
+    };
+
+    auto const not_found = [&req](boost::beast::string_view target)
+    {
+        http::response<http::string_body> res{http::status::not_found, req.version()};
+        res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+        res.set(http::field::content_type, "text/plain");
+        res.keep_alive(req.keep_alive());
+        res.body() = "The resource '" + std::string(target) + "' was not found.";
+        res.prepare_payload();
+        return res;
+    };
+
+    auto const server_error = [&req](boost::beast::string_view what)
+    {
+        http::response<http::string_body> res{http::status::internal_server_error, req.version()};
+        res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+        res.set(http::field::content_type, "text/plain");
+        res.keep_alive(req.keep_alive());
+        res.body() = "An error occurred: '" + std::string(what) + "'";
+        res.prepare_payload();
+        return res;
+    };
+
+    auto const command_response = [&req](std::string_view content)
+    {
+        http::response<http::string_body> res{http::status::ok, req.version()};
+        res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+        res.set(http::field::content_type, "application/json");
+        res.keep_alive(req.keep_alive());
+        res.body() = content;
+        res.prepare_payload();
+        return res;
+    };
+
+    if (req.target().substr(0, 5) == "/api/")
+    {
+        std::string cmd = req.target().substr(5).to_string();
+        BOOST_LOG_TRIVIAL(debug) << "Running RPC command '" << cmd << "'";
+
+        json j;
+
+        if (req.method() == http::verb::post)
+        {
+            j = json::parse(req.body());
+        }
+
+        auto res = m_commands.at(cmd)->execute(j);
+        queue_(command_response(res.dump()));
+    }
+    else if(doc_root_ == nullptr)
+    {
+        queue_(not_found(req.target()));
+    }
+    else
+    {
+        if (req.target().empty() ||
+            req.target()[0] != '/' ||
+            req.target().find("..") != boost::beast::string_view::npos)
+        {
+            queue_(bad_request("Illegal request-target"));
+        }
+        else
+        {
+            std::string path = path_cat(*doc_root_, req.target());
+            if(req.target().back() == '/') { path.append("index.html"); }
+
+            boost::beast::error_code ec;
+            http::file_body::value_type body;
+            body.open(path.c_str(), boost::beast::file_mode::scan, ec);
+
+            if(ec == boost::beast::errc::no_such_file_or_directory)
+            {
+                queue_(not_found(req.target()));
+            }
+            else if (ec)
+            {
+                queue_(server_error(ec.message()));
+            }
+            else
+            {
+                auto const size = body.size();
+
+                http::response<http::file_body> res{
+                    std::piecewise_construct,
+                    std::make_tuple(std::move(body)),
+                    std::make_tuple(http::status::ok, req.version())};
+                res.set(http::field::server, BOOST_BEAST_VERSION_STRING);
+                res.set(http::field::content_type, mime_type(path));
+                res.content_length(size);
+                res.keep_alive(req.keep_alive());
+
+                queue_(std::move(res));
+            }
+        }
+    }
+
+    // If we aren't at the queue limit, try to pipeline another request
+    if(!queue_.is_full())
+    {
+        do_read();
+    }
+}
+
+void http_session::on_write(bool close, boost::beast::error_code ec, std::size_t bytes_transferred)
+{
+    boost::ignore_unused(bytes_transferred);
+
+    if (ec)
+    {
+        // TODO (log)
+        return;
+    }
+
+    if (close)
+    {
+        // This means we should close the connection, usually because
+        // the response indicated the "Connection: close" semantic.
+        return do_close();
+    }
+
+    // Inform the queue that a write completed
+    if (queue_.on_write())
+    {
+        // Read another request
+        do_read();
+    }
+}
+
+void http_session::do_close()
+{
+    // Send a TCP shutdown
+    boost::beast::error_code ec;
+    stream_.socket().shutdown(boost::asio::ip::tcp::socket::shutdown_send, ec);
+}

--- a/src/server/http/http_session.hpp
+++ b/src/server/http/http_session.hpp
@@ -15,15 +15,11 @@
 #include <sqlite3.h>
 
 
-namespace pt
-{
-    class session_manager;
-}
+namespace pt { class session_manager; }
+namespace pt::commands { class command;  }
 
 namespace pt::http
 {
-    class command;
-
     class http_session : public std::enable_shared_from_this<http_session>
     {
         // This queue is used for HTTP pipelining.
@@ -116,6 +112,7 @@ namespace pt::http
             boost::asio::ip::tcp::socket&& socket,
             sqlite3* db,
             std::shared_ptr<session_manager> const& session_manager,
+            std::shared_ptr<std::map<std::string, std::shared_ptr<pt::commands::command>>> const& commands,
             std::shared_ptr<std::string const> const& doc_root);
 
         void run();
@@ -131,7 +128,7 @@ namespace pt::http
         sqlite3* m_db;
         std::shared_ptr<session_manager> m_session_manager;
         std::shared_ptr<std::string const> doc_root_;
-        std::map<std::string, std::shared_ptr<command>> m_commands;
+        std::shared_ptr<std::map<std::string, std::shared_ptr<pt::commands::command>>> m_commands;
         queue queue_;
 
         // The parser is stored in an optional container so we can

--- a/src/server/http/http_session.hpp
+++ b/src/server/http/http_session.hpp
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/websocket.hpp>
+#include <boost/beast/version.hpp>
+#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/asio/strand.hpp>
+#include <sqlite3.h>
+
+
+namespace pt
+{
+    class session_manager;
+}
+
+namespace pt::http
+{
+    class command;
+
+    class http_session : public std::enable_shared_from_this<http_session>
+    {
+        // This queue is used for HTTP pipelining.
+        class queue
+        {
+            enum
+            {
+                // Maximum number of responses we will queue
+                limit = 8
+            };
+
+            // The type-erased, saved work item
+            struct work
+            {
+                virtual ~work() = default;
+                virtual void operator()() = 0;
+            };
+
+            http_session& self_;
+            std::vector<std::unique_ptr<work>> items_;
+
+        public:
+            explicit queue(http_session& self)
+                : self_(self)
+            {
+                static_assert(limit > 0, "queue limit must be positive");
+                items_.reserve(limit);
+            }
+
+            // Returns `true` if we have reached the queue limit
+            bool is_full() const
+            {
+                return items_.size() >= limit;
+            }
+
+            // Called when a message finishes sending
+            // Returns `true` if the caller should initiate a read
+            bool on_write()
+            {
+                BOOST_ASSERT(!items_.empty());
+                auto const was_full = is_full();
+                items_.erase(items_.begin());
+                if(! items_.empty())
+                    (*items_.front())();
+                return was_full;
+            }
+
+            // Called by the HTTP handler to send a response.
+            template<bool isRequest, class Body, class Fields>
+            void operator()(boost::beast::http::message<isRequest, Body, Fields>&& msg)
+            {
+                // This holds a work item
+                struct work_impl : work
+                {
+                    http_session& self_;
+                    boost::beast::http::message<isRequest, Body, Fields> msg_;
+
+                    work_impl(
+                        http_session& self,
+                        boost::beast::http::message<isRequest, Body, Fields>&& msg)
+                        : self_(self)
+                        , msg_(std::move(msg))
+                    {
+                    }
+
+                    void operator()()
+                    {
+                        boost::beast::http::async_write(
+                            self_.stream_,
+                            msg_,
+                            boost::beast::bind_front_handler(
+                                &http_session::on_write,
+                                self_.shared_from_this(),
+                                msg_.need_eof()));
+                    }
+                };
+
+                // Allocate and store the work
+                items_.push_back(
+                    std::make_unique<work_impl>(self_, std::move(msg)));
+
+                // If there was no previous work, start this one
+                if(items_.size() == 1)
+                    (*items_.front())();
+            }
+        };
+
+    public:
+        http_session(
+            boost::asio::ip::tcp::socket&& socket,
+            sqlite3* db,
+            std::shared_ptr<session_manager> const& session_manager,
+            std::shared_ptr<std::string const> const& doc_root);
+
+        void run();
+
+    private:
+        void do_read();
+        void on_read(boost::beast::error_code ec, std::size_t bytes_transferred);
+        void on_write(bool close, boost::beast::error_code ec, std::size_t bytes_transferred);
+        void do_close();
+
+        boost::beast::tcp_stream stream_;
+        boost::beast::flat_buffer buffer_;
+        sqlite3* m_db;
+        std::shared_ptr<session_manager> m_session_manager;
+        std::shared_ptr<std::string const> doc_root_;
+        std::map<std::string, std::shared_ptr<command>> m_commands;
+        queue queue_;
+
+        // The parser is stored in an optional container so we can
+        // construct it from scratch it at the beginning of each new message.
+        boost::optional<boost::beast::http::request_parser<boost::beast::http::string_body>> parser_;
+    };
+}

--- a/src/server/http/mime_type.hpp
+++ b/src/server/http/mime_type.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <boost/beast.hpp>
+
+boost::beast::string_view mime_type(boost::beast::string_view path)
+{
+    namespace beast = boost::beast;
+    using beast::iequals;
+
+    auto const ext = [&path]
+    {
+        auto const pos = path.rfind(".");
+        if(pos == beast::string_view::npos)
+            return beast::string_view{};
+        return path.substr(pos);
+    }();
+
+    if(iequals(ext, ".htm"))  return "text/html";
+    if(iequals(ext, ".html")) return "text/html";
+    if(iequals(ext, ".php"))  return "text/html";
+    if(iequals(ext, ".css"))  return "text/css";
+    if(iequals(ext, ".txt"))  return "text/plain";
+    if(iequals(ext, ".js"))   return "application/javascript";
+    if(iequals(ext, ".json")) return "application/json";
+    if(iequals(ext, ".xml"))  return "application/xml";
+    if(iequals(ext, ".swf"))  return "application/x-shockwave-flash";
+    if(iequals(ext, ".flv"))  return "video/x-flv";
+    if(iequals(ext, ".png"))  return "image/png";
+    if(iequals(ext, ".jpe"))  return "image/jpeg";
+    if(iequals(ext, ".jpeg")) return "image/jpeg";
+    if(iequals(ext, ".jpg"))  return "image/jpeg";
+    if(iequals(ext, ".gif"))  return "image/gif";
+    if(iequals(ext, ".bmp"))  return "image/bmp";
+    if(iequals(ext, ".ico"))  return "image/vnd.microsoft.icon";
+    if(iequals(ext, ".tiff")) return "image/tiff";
+    if(iequals(ext, ".tif"))  return "image/tiff";
+    if(iequals(ext, ".svg"))  return "image/svg+xml";
+    if(iequals(ext, ".svgz")) return "image/svg+xml";
+
+    return "application/text";
+}

--- a/src/server/http/path_cat.hpp
+++ b/src/server/http/path_cat.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+#include <boost/beast.hpp>
+
+std::string path_cat(
+    boost::beast::string_view base,
+    boost::beast::string_view path)
+{
+    if(base.empty())
+        return std::string(path);
+    std::string result(base);
+#ifdef BOOST_MSVC
+    char constexpr path_separator = '\\';
+    if(result.back() == path_separator)
+        result.resize(result.size() - 1);
+    result.append(path.data(), path.size());
+    for(auto& c : result)
+        if(c == '/')
+            c = path_separator;
+#else
+    char constexpr path_separator = '/';
+    if(result.back() == path_separator)
+        result.resize(result.size() - 1);
+    result.append(path.data(), path.size());
+#endif
+    return result;
+}

--- a/src/server/http/websocket_session.cpp
+++ b/src/server/http/websocket_session.cpp
@@ -1,0 +1,124 @@
+#include "websocket_session.hpp"
+
+#include <boost/log/trivial.hpp>
+#include <libtorrent/add_torrent_params.hpp>
+#include <libtorrent/torrent_info.hpp>
+#include <libtorrent/torrent_status.hpp>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+using pt::http::websocket_session;
+
+websocket_session::websocket_session(
+    boost::asio::ip::tcp::socket&& socket,
+    sqlite3* db,
+    std::shared_ptr<pt::session_manager> session)
+    : m_websocket(std::move(socket)),
+    m_db(db),
+    m_session(session)
+{
+    /*m_subscriber_tag = m_session->subscribe(
+        std::bind(&websocket_session::on_subscribe, this, std::placeholders::_1));*/
+}
+
+void websocket_session::begin_accept(boost::system::error_code ec)
+{
+    if (ec)
+    {
+        return;
+    }
+
+    json j;
+    j["type"] = "init";
+    j["torrents"] = json::object();
+
+    /*m_session->for_each_torrent(
+        [&j](auto const& ts)
+        {
+            std::stringstream ss;
+            if (ts.info_hashes.has_v2()) { ss << ts.info_hashes.v2; }
+            else { ss << ts.info_hashes.v1; }
+
+            json torrent;
+            torrent["name"] = ts.name;
+            torrent["progress"] = ts.progress;
+            torrent["save_path"] = ts.save_path;
+            torrent["size_wanted"] = ts.total_wanted;
+            torrent["state"] = ts.state;
+            torrent["dl"] = ts.download_payload_rate;
+            torrent["ul"] = ts.upload_payload_rate;
+            torrent["info_hash"] = ss.str();
+
+            j["torrents"][ss.str()] = torrent;
+
+            return true;
+        });*/
+
+    BOOST_LOG_TRIVIAL(debug) << "Sending initial state to client";
+
+    m_send_data.push(j.dump());
+    maybe_write();
+
+    begin_read();
+}
+
+void websocket_session::begin_read()
+{
+    m_websocket.async_read(
+        m_buffer,
+        boost::beast::bind_front_handler(
+            &websocket_session::end_read,
+            shared_from_this()));
+}
+
+void websocket_session::end_read(boost::system::error_code ec, std::size_t bytes_transferred)
+{
+    if (ec == boost::beast::websocket::error::closed)
+    {
+        return;
+    }
+
+    if (ec)
+    {
+        BOOST_LOG_TRIVIAL(error) << "Error when reading from WebSocket: " << ec.message();
+        return;
+    }
+
+    begin_read();
+}
+
+void websocket_session::end_write(boost::beast::error_code ec, std::size_t bytes_transferred)
+{
+    m_is_writing = false;
+    m_send_data.pop();
+
+    if (ec)
+    {
+        BOOST_LOG_TRIVIAL(error) << "Failed to write " << bytes_transferred << " bytes: " << ec;
+        return;
+    }
+
+    maybe_write();
+}
+
+void websocket_session::maybe_write()
+{
+    if (m_is_writing
+        || m_send_data.empty()) { return; };
+
+    std::string& d = m_send_data.front();
+
+    m_websocket.async_write(
+        boost::asio::buffer(d),
+        boost::beast::bind_front_handler(
+            &websocket_session::end_write,
+            shared_from_this()));
+
+    m_is_writing = true;
+}
+
+void websocket_session::on_subscribe(json& j)
+{
+    m_send_data.push(j.dump());
+    maybe_write();
+}

--- a/src/server/http/websocket_session.hpp
+++ b/src/server/http/websocket_session.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <memory>
+#include <queue>
+#include <string>
+
+#include <boost/beast.hpp>
+#include <nlohmann/json.hpp>
+#include <sqlite3.h>
+
+namespace pt
+{
+    class session_manager;
+}
+
+namespace pt::http
+{
+    class websocket_session : public std::enable_shared_from_this<websocket_session>
+    {
+    public:
+        explicit websocket_session(
+            boost::asio::ip::tcp::socket&& socket,
+            sqlite3* db,
+            std::shared_ptr<session_manager> session);
+
+        template<class Body, class Allocator>
+        void run(boost::beast::http::request<Body, boost::beast::http::basic_fields<Allocator>> req)
+        {
+            // Set suggested timeout settings for the websocket
+            m_websocket.set_option(boost::beast::websocket::stream_base::timeout::suggested(boost::beast::role_type::server));
+
+            // Set a decorator to change the Server of the handshake
+            m_websocket.set_option(boost::beast::websocket::stream_base::decorator(
+                [](boost::beast::websocket::response_type& res)
+                {
+                    res.set(boost::beast::http::field::server, "bt-dl/1.0");
+                }));
+
+            // Accept the websocket handshake
+            m_websocket.async_accept(
+                req,
+                boost::beast::bind_front_handler(
+                    &websocket_session::begin_accept,
+                    shared_from_this()));
+        }
+
+    private:
+        void begin_accept(boost::system::error_code ec);
+        void begin_read();
+        void end_read(boost::system::error_code ec, size_t bytes_transferred);
+        void end_write(boost::system::error_code ec, size_t bytes_transferred);
+        void maybe_write();
+        void on_subscribe(nlohmann::json& j);
+
+        boost::beast::websocket::stream<boost::beast::tcp_stream> m_websocket;
+        boost::beast::flat_buffer m_buffer;
+        sqlite3* m_db;
+        std::shared_ptr<session_manager> m_session;
+        bool m_is_writing{ false };
+        std::queue<std::string> m_send_data;
+        std::shared_ptr<void> m_subscriber_tag;
+    };
+}

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -1,0 +1,47 @@
+#include <boost/asio.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/log/trivial.hpp>
+#include <libtorrent/session.hpp>
+#include <nlohmann/json.hpp>
+#include <sqlite3.h>
+
+#include "http/http_listener.hpp"
+
+int main(int argc, char* argv[])
+{
+    BOOST_LOG_TRIVIAL(info) << "PicoTorrent Server launching...";
+
+    sqlite3* db;
+    sqlite3_open(":memory:", &db);
+
+    boost::asio::io_context io;
+
+    boost::asio::signal_set signals(io, SIGINT, SIGTERM);
+    signals.async_wait(
+        [&io](boost::system::error_code const& ec, int signal)
+        {
+            io.stop();
+        });
+
+    nlohmann::json j;
+    j["foo"] = "bar";
+
+    libtorrent::session session;
+
+    auto http = std::make_shared<pt::http::http_listener>(
+        io,
+        boost::asio::ip::tcp::endpoint{ boost::asio::ip::make_address("0.0.0.0"), 6545 },
+        db,
+        nullptr,
+        nullptr);
+
+    http->run();
+
+    io.run();
+
+    BOOST_LOG_TRIVIAL(info) << "PicoTorrent Server shutting down...";
+
+    sqlite3_close(db);
+
+    return 0;
+}

--- a/src/server/session_manager.cpp
+++ b/src/server/session_manager.cpp
@@ -1,0 +1,554 @@
+#include "session_manager.hpp"
+
+#include <boost/log/trivial.hpp>
+#include <libtorrent/alert_types.hpp>
+#include <libtorrent/create_torrent.hpp>
+#include <libtorrent/read_resume_data.hpp>
+#include <libtorrent/session.hpp>
+#include <libtorrent/write_resume_data.hpp>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+namespace lt = libtorrent;
+using pt::session_manager;
+
+struct torrent_options
+{
+    bool is_initial;
+};
+
+static std::string to_str(lt::info_hash_t hash)
+{
+    std::stringstream ss;
+    if (hash.has_v2()) { ss << hash.v2; }
+    else { ss << hash.v1; }
+    return ss.str();
+}
+
+static bool load_settings_pack(sqlite3* db, lt::settings_pack& settings)
+{
+    int res = sqlite3_exec(
+        db,
+        "SELECT name, value FROM settings WHERE name LIKE 'libtorrent.%' AND value IS NOT NULL",
+        [](void* user, int, char** data, char**)
+        {
+            lt::settings_pack* sp = static_cast<lt::settings_pack*>(user);
+
+            json j;
+
+            try
+            {
+                j = json::parse(data[1]);
+            }
+            catch(const std::exception& e)
+            {
+                BOOST_LOG_TRIVIAL(warning) << "Failed to parse setting '" << data[0] << "' as JSON: " << e.what() << ", value: " << data[1];
+                return SQLITE_OK;
+            }
+
+            std::string name = data[0];
+            name = name.substr(strlen("libtorrent.")); // trim 'libtorrent.'
+            int setting = lt::setting_by_name(name);
+
+            if (setting == -1)
+            {
+                BOOST_LOG_TRIVIAL(warning) << "Unknown libtorrent setting: " << name;
+                return SQLITE_OK;
+            }
+
+            BOOST_LOG_TRIVIAL(debug) << "Setting '" << name << "' to " << j;
+
+            if (setting >= lt::settings_pack::string_type_base
+                && setting < lt::settings_pack::max_string_setting_internal)
+            {
+                sp->set_str(setting, j);
+            }
+            else if (setting >= lt::settings_pack::int_type_base
+                && setting < lt::settings_pack::max_int_setting_internal)
+            {
+                sp->set_int(setting, j);
+            }
+            else if (setting >= lt::settings_pack::bool_type_base
+                && setting < lt::settings_pack::max_bool_setting_internal)
+            {
+                sp->set_bool(setting, j);
+            }
+            else
+            {
+                BOOST_LOG_TRIVIAL(warning) << "Failed to determine type of setting for '" << name << "', " << setting;
+            }
+
+            return SQLITE_OK;
+        },
+        &settings,
+        nullptr);
+
+    return true;
+}
+
+std::shared_ptr<session_manager> session_manager::load(boost::asio::io_context& io, sqlite3* db)
+{
+    BOOST_LOG_TRIVIAL(info) << "Reading session params";
+
+    lt::session_params params;
+
+    {
+        sqlite3_stmt* stmt;
+        sqlite3_prepare_v2(db, "SELECT data FROM session_params ORDER BY timestamp DESC LIMIT 1", -1, &stmt, nullptr);
+        if (sqlite3_step(stmt) == SQLITE_ROW)
+        {
+            int len = sqlite3_column_bytes(stmt, 0);
+            const char* buf = static_cast<const char*>(sqlite3_column_blob(stmt, 0));
+
+            lt::error_code ec;
+            lt::bdecode_node node = lt::bdecode(lt::span<const char>(buf, len), ec);
+
+            if (ec)
+            {
+                BOOST_LOG_TRIVIAL(warning) << "Failed to bdecode session params buffer: " << ec.message();
+            }
+            else
+            {
+                params = lt::read_session_params(node, lt::session::save_dht_state);
+                BOOST_LOG_TRIVIAL(info) << "Loaded session params (" << len << " bytes)";
+            }
+        }
+
+        sqlite3_finalize(stmt);
+    }
+
+    if (!load_settings_pack(db, params.settings))
+    {
+        BOOST_LOG_TRIVIAL(warning) << "Failed to read session settings: " << sqlite3_errmsg(db);
+    }
+
+    auto sm = std::shared_ptr<session_manager>(
+        new session_manager(io, db, std::make_unique<lt::session>(params)));
+    sm->load_torrents();
+
+    return std::move(sm);
+}
+
+session_manager::session_manager(boost::asio::io_context& io, sqlite3* db, std::unique_ptr<lt::session> session)
+    : m_io(io),
+    m_db(db),
+    m_session(std::move(session)),
+    m_torrents(),
+    m_timer(io)
+{
+    m_session->set_alert_notify(
+        [this]()
+        {
+            boost::asio::post(
+                m_io,
+                std::bind(
+                    &session_manager::read_alerts,
+                    this));
+        });
+
+    boost::system::error_code ec;
+    m_timer.expires_from_now(boost::posix_time::seconds(1), ec);
+    m_timer.async_wait(
+        std::bind(&session_manager::post_updates, this, std::placeholders::_1));
+}
+
+session_manager::~session_manager()
+{
+    BOOST_LOG_TRIVIAL(info) << "Saving session state";
+
+    m_session->set_alert_notify([] {});
+    m_timer.cancel();
+
+    {
+        std::vector<char> stateBuffer = lt::write_session_params_buf(
+            m_session->session_state(),
+            lt::session::save_dht_state);
+
+        BOOST_LOG_TRIVIAL(debug) << "Saving session params (" << stateBuffer.size() << " bytes)";
+
+        sqlite3_stmt* stmt;
+        sqlite3_prepare_v2(m_db, "INSERT INTO session_params (data, timestamp) VALUES ($1, strftime('%s'));", -1, &stmt, nullptr);
+        sqlite3_bind_blob(stmt, 1, stateBuffer.data(), static_cast<int>(stateBuffer.size()), SQLITE_TRANSIENT);
+
+        if (sqlite3_step(stmt) != SQLITE_DONE)
+        {
+            BOOST_LOG_TRIVIAL(warning) << "Failed to save session params data: " << sqlite3_errmsg(m_db);
+        }
+
+        sqlite3_finalize(stmt);
+    }
+
+    m_session->pause();
+
+    // Save each torrents resume data
+    int num_outstanding_resume = 0;
+    int num_paused = 0;
+    int num_failed = 0;
+
+    auto temp = m_session->get_torrent_status([](lt::torrent_status const&) { return true; });
+
+    for (lt::torrent_status& st : temp)
+    {
+        if (!st.handle.is_valid()
+            || !st.has_metadata
+            || !st.need_save_resume)
+        {
+            continue;
+        }
+
+        st.handle.save_resume_data(
+            lt::torrent_handle::flush_disk_cache
+            | lt::torrent_handle::save_info_dict);
+
+        ++num_outstanding_resume;
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "Saving data for " << num_outstanding_resume << " torrent(s)";
+
+    sqlite3_stmt* stmt;
+    sqlite3_prepare_v2(m_db, "UPDATE torrents SET queue_position = $1, resume_data = $2 WHERE info_hash = $3", -1, &stmt, nullptr);
+
+    while (num_outstanding_resume > 0)
+    {
+        lt::alert const* tmp = m_session->wait_for_alert(lt::seconds(10));
+        if (tmp == nullptr) { continue; }
+
+        std::vector<lt::alert*> alerts;
+        m_session->pop_alerts(&alerts);
+
+        for (lt::alert* a : alerts)
+        {
+            lt::torrent_paused_alert* tp = lt::alert_cast<lt::torrent_paused_alert>(a);
+
+            if (tp)
+            {
+                ++num_paused;
+                continue;
+            }
+
+            if (lt::alert_cast<lt::save_resume_data_failed_alert>(a))
+            {
+                ++num_failed;
+                --num_outstanding_resume;
+                continue;
+            }
+
+            lt::save_resume_data_alert* rd = lt::alert_cast<lt::save_resume_data_alert>(a);
+            if (!rd) { continue; }
+            --num_outstanding_resume;
+
+            std::vector<char> buffer = lt::write_resume_data_buf(rd->params);
+            std::string info_hash = to_str(rd->handle.info_hashes());
+
+            // Store state
+            sqlite3_bind_int(stmt, 1, static_cast<int>(rd->handle.status().queue_position));
+            sqlite3_bind_blob(stmt, 2, buffer.data(), static_cast<int>(buffer.size()), SQLITE_TRANSIENT);
+            sqlite3_bind_text(stmt, 3, info_hash.c_str(), -1, SQLITE_TRANSIENT);
+
+            if (sqlite3_step(stmt) != SQLITE_DONE)
+            {
+                BOOST_LOG_TRIVIAL(warning) << "Failed to save resume data for torrent " << info_hash << ": " << sqlite3_errmsg(m_db);
+            }
+
+            sqlite3_reset(stmt);
+        }
+    }
+
+    sqlite3_finalize(stmt);
+
+    BOOST_LOG_TRIVIAL(info) << "Session state saved";
+}
+
+lt::info_hash_t session_manager::add_torrent(lt::add_torrent_params& params)
+{
+    params.userdata = lt::client_data_t(new torrent_options());
+
+    m_session->async_add_torrent(params);
+
+    return params.ti
+        ? params.ti->info_hashes()
+        : params.info_hashes;
+}
+
+void session_manager::for_each_torrent(std::function<bool(libtorrent::torrent_status const& ts)> const& iteree)
+{
+    for (auto const& item : m_torrents)
+    {
+        if (!iteree(item.second)) break;
+    }
+}
+
+void session_manager::pause_torrent(lt::info_hash_t const& hash)
+{
+    m_torrents.at(hash).handle.pause();
+}
+
+void session_manager::reload_settings()
+{
+    lt::settings_pack sp;
+    if (load_settings_pack(m_db, sp))
+    {
+        m_session->apply_settings(sp);
+    }
+}
+void session_manager::remove_torrent(lt::info_hash_t const& hash, bool remove_files)
+{
+    m_session->remove_torrent(
+        m_torrents.at(hash).handle);
+}
+
+std::shared_ptr<void> session_manager::subscribe(std::function<void(nlohmann::json&)> sub)
+{
+    auto ptr = std::make_shared<std::function<void(json&)>>(std::move(sub));
+    m_subscribers.push_back(ptr);
+    return ptr;
+}
+
+void session_manager::broadcast(json& j)
+{
+    size_t sz = m_subscribers.size();
+
+    m_subscribers.erase(
+        std::remove_if(
+            m_subscribers.begin(),
+            m_subscribers.end(),
+            [](auto& ptr) { return ptr.expired(); }),
+        m_subscribers.end());
+
+    size_t pruned = sz - m_subscribers.size();
+
+    if (pruned > 0)
+    {
+        BOOST_LOG_TRIVIAL(debug) << "Pruned " << pruned << " subscriber";
+    }
+
+    auto tmp = m_subscribers;
+
+    for (auto pf : tmp)
+    {
+        if (auto s = pf.lock())
+        {
+            (*s)(j);
+        }
+    }
+}
+
+void session_manager::load_torrents()
+{
+    sqlite3_stmt* stmt;
+    sqlite3_prepare_v2(m_db, "SELECT info_hash, resume_data, torrent_data FROM torrents ORDER BY queue_position ASC", -1, &stmt, nullptr);
+
+    BOOST_LOG_TRIVIAL(info) << "Loading torrent state";
+
+    while (true)
+    {
+        int res = sqlite3_step(stmt);
+
+        if (res != SQLITE_ROW)
+        {
+            if (res == SQLITE_ERROR)
+            {
+                BOOST_LOG_TRIVIAL(warning) << "Failed to step: " << sqlite3_errmsg(m_db);
+            }
+
+            break;
+        }
+
+        const char* info_hash = reinterpret_cast<const char*>(sqlite3_column_text(stmt, 0));
+
+        int resume_len = sqlite3_column_bytes(stmt, 1);
+        const char* resume_buf = static_cast<const char*>(sqlite3_column_blob(stmt, 1));
+
+        int torrent_len = sqlite3_column_bytes(stmt, 2);
+        const char* torrent_buf = static_cast<const char*>(sqlite3_column_blob(stmt, 2));
+
+        lt::error_code ec;
+        lt::add_torrent_params params;
+
+        if (resume_len > 0)
+        {
+            params = lt::read_resume_data({ resume_buf, resume_len }, ec);
+        }
+
+        if (ec)
+        {
+            BOOST_LOG_TRIVIAL(warning) << "Failed to read resume data for torrent: " << ec.message();
+            continue;
+        }
+
+        lt::bdecode_node node = lt::bdecode({ torrent_buf, torrent_len }, ec);
+
+        if (ec)
+        {
+            BOOST_LOG_TRIVIAL(warning) << "Failed to parse torrent data for torrent: " << ec.message();
+            continue;
+        }
+
+        auto extra = new torrent_options();
+        extra->is_initial = true;
+
+        params.ti = std::make_shared<lt::torrent_info>(node);
+        params.userdata = lt::client_data_t(extra);
+
+        m_session->async_add_torrent(params);
+        m_initial_torrents++;
+    }
+
+    sqlite3_finalize(stmt);
+}
+
+void session_manager::read_alerts()
+{
+    std::vector<lt::alert*> alerts;
+    m_session->pop_alerts(&alerts);
+
+    for (auto const& alert : alerts)
+    {
+        switch (alert->type())
+        {
+        case lt::add_torrent_alert::alert_type:
+        {
+            lt::add_torrent_alert* ata = lt::alert_cast<lt::add_torrent_alert>(alert);
+            lt::torrent_status ts = ata->handle.status();
+
+            auto opts = std::unique_ptr<torrent_options>(ata->params.userdata.get<torrent_options>());
+
+            if (opts == nullptr)
+            {
+                BOOST_LOG_TRIVIAL(error) << "No torrent_options for " << to_str(ts.info_hashes);
+            }
+
+            if (opts->is_initial)
+            {
+                m_initial_loaded++;
+            }
+
+            if (m_initial_torrents == m_initial_loaded)
+            {
+                BOOST_LOG_TRIVIAL(info) << "Torrent state loaded for " << m_initial_loaded << " torrent(s)";
+            }
+
+            if (ata->error)
+            {
+                BOOST_LOG_TRIVIAL(error) << "Error when adding torrent: " << ata->error;
+                return;
+            }
+
+            if (!opts->is_initial)
+            {
+                BOOST_LOG_TRIVIAL(info) << "Torrent " << to_str(ata->handle.info_hashes()) << " added";
+            }
+
+            m_torrents.insert({ ts.info_hashes, ts });
+
+            if (!opts->is_initial)
+            {
+                BOOST_LOG_TRIVIAL(info) << "Saving torrent " << to_str(ts.info_hashes) << " in database";
+
+                lt::create_torrent ct(*ata->params.ti.get());
+                std::vector<char> buffer;
+                lt::bencode(std::back_inserter(buffer), ct.generate());
+
+                // store in database
+                sqlite3_stmt* stmt;
+                sqlite3_prepare_v2(m_db, "INSERT INTO torrents (info_hash, queue_position, torrent_data) VALUES($1, $2, $3);", -1, &stmt, nullptr);
+                sqlite3_bind_text(stmt, 1, to_str(ts.info_hashes).c_str(), -1, SQLITE_TRANSIENT);
+                sqlite3_bind_int(stmt, 2, static_cast<int>(ts.queue_position));
+                sqlite3_bind_blob(stmt, 3, buffer.data(), static_cast<int>(buffer.size()), SQLITE_TRANSIENT);
+                sqlite3_step(stmt);
+                sqlite3_finalize(stmt);
+
+                BOOST_LOG_TRIVIAL(debug) << "Stored torrent in database (" << buffer.size() << " bytes)";
+            }
+
+            json j;
+            j["type"] = "torrent.added";
+            j["info_hash"] = to_str(ts.info_hashes);
+            j["name"] = ata->handle.status().name;
+            j["progress"] = ts.progress;
+            j["save_path"] = ts.save_path;
+            j["size_wanted"] = ts.total_wanted;
+            j["state"] = ts.state;
+            j["muted"] = opts->is_initial;
+            j["dl"] = ts.download_payload_rate;
+            j["ul"] = ts.upload_payload_rate;
+
+            broadcast(j);
+
+            break;
+        }
+        case lt::state_update_alert::alert_type:
+        {
+            lt::state_update_alert* sua = lt::alert_cast<lt::state_update_alert>(alert);
+
+            json j;
+            j["type"] = "torrent.updated";
+            j["torrents"] = json::object();
+
+            for (auto const& status : sua->status)
+            {
+                m_torrents.at(status.info_hashes) = status;
+
+                json t;
+                t["info_hash"] = to_str(status.info_hashes);
+                t["name"] = status.name;
+                t["progress"] = status.progress;
+                t["save_path"] = status.save_path;
+                t["size_wanted"] = status.total_wanted;
+                t["state"] = status.state;
+                t["dl"] = status.download_payload_rate;
+                t["ul"] = status.upload_payload_rate;
+
+                j["torrents"][to_str(status.info_hashes)] = t;
+            }
+
+            if (sua->status.size() > 0)
+            {
+                broadcast(j);
+            }
+
+            break;
+        }
+        case lt::torrent_removed_alert::alert_type:
+        {
+            lt::torrent_removed_alert* tra = lt::alert_cast<lt::torrent_removed_alert>(alert);
+            std::string info_hash = to_str(tra->info_hashes);
+
+            BOOST_LOG_TRIVIAL(info) << "Removing torrent " << info_hash;
+
+            m_torrents.erase(tra->info_hashes);
+
+            sqlite3_stmt* stmt;
+            sqlite3_prepare_v2(m_db, "DELETE FROM torrents WHERE info_hash = $1", -1, &stmt, nullptr);
+            sqlite3_bind_text(stmt, 1, info_hash.c_str(), -1, SQLITE_TRANSIENT);
+            sqlite3_step(stmt);
+            sqlite3_finalize(stmt);
+
+            json j;
+            j["type"] = "torrent.removed";
+            j["info_hash"] = info_hash;
+
+            broadcast(j);
+
+            break;
+        }
+        }
+    }
+}
+
+void session_manager::post_updates(boost::system::error_code ec)
+{
+    if (ec)
+    {
+        BOOST_LOG_TRIVIAL(error) << "error in timer: " << ec;
+        return;
+    }
+
+    m_session->post_dht_stats();
+    m_session->post_session_stats();
+    m_session->post_torrent_updates();
+
+    m_timer.expires_from_now(boost::posix_time::seconds(1), ec);
+    m_timer.async_wait(
+        std::bind(&session_manager::post_updates, this, std::placeholders::_1));
+}

--- a/src/server/session_manager.hpp
+++ b/src/server/session_manager.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+
+#include <boost/asio.hpp>
+#include <libtorrent/fwd.hpp>
+#include <nlohmann/json.hpp>
+#include <sqlite3.h>
+
+namespace pt
+{
+    class session_manager
+    {
+    public:
+        static std::shared_ptr<session_manager> load(boost::asio::io_context& io, sqlite3* db);
+
+        ~session_manager();
+
+        libtorrent::info_hash_t add_torrent(libtorrent::add_torrent_params& params);
+        void for_each_torrent(std::function<bool(libtorrent::torrent_status const& ts)> const&);
+        void pause_torrent(libtorrent::info_hash_t const& hash);
+        void reload_settings();
+        void remove_torrent(libtorrent::info_hash_t const& hash, bool remove_files = false);
+        std::shared_ptr<void> subscribe(std::function<void(nlohmann::json&)>);
+
+    private:
+        session_manager(boost::asio::io_context& io, sqlite3* db, std::unique_ptr<libtorrent::session> session);
+
+        void broadcast(nlohmann::json&);
+        void load_torrents();
+        void read_alerts();
+        void post_updates(boost::system::error_code ec);
+
+        boost::asio::io_context& m_io;
+        boost::asio::deadline_timer m_timer;
+
+        sqlite3* m_db;
+        std::unique_ptr<libtorrent::session> m_session;
+        size_t m_initial_torrents = 0;
+        size_t m_initial_loaded = 0;
+        std::map<libtorrent::info_hash_t, libtorrent::torrent_status> m_torrents;
+        std::vector<std::weak_ptr<std::function<void(nlohmann::json&)>>> m_subscribers;
+    };
+}


### PR DESCRIPTION
This will add a PicoTorrent Server process which will be used for all BitTorrent related things, keeping the UI clean from libtorrent and adding a WebSocket and HTTP JSONRPC API to the server process. Ideally with no breaking changes.

The server process will have a HTTP listener where you can connect to either `/api/ws` to receive WebSocket events, or `/api/jsonrpc` to post JSONRPC requests. It will also add support for serving static files under `/` which can be used for serving a SPA for remote management.

The basic idea here is to have a server process which can be run either as part of the client, or stand-alone and connect either a regular PicoTorrent desktop client to it or managed by the web UI. The desktop application will receive events on the WebSocket to keep UI in sync, and issue JSONRPC requests to modify state.

JSONRPC methods to implement:
- [ ] `core.getVersion` - gets version information for all libraries.
- [ ] `config.get` - gets the application config, i.e can be anything the application chooses to store.
- [ ] `config.set` - sets a config value, anything the application wants.
- [ ] `session.findMetadata` - begins a DHT metadata search for a torrent based on a info hash.
- [ ] `session.getSettings` - get the libtorrent session settings.
- [ ] `session.setSettings` - sets the libtorrent session settings.
- [ ] `session.pause` - pauses the session.
- [ ] `session.resume` - resumes the session.
- [ ] `session.setIPFilter` - sets the IP filter configuration.
- [ ] `session.getIPFilter` - gets the IP filter configuration.
- [ ] `session.addTorrent` - adds a torrent.
- [ ] `torrents.toJSON` - takes a base64 encoded torrent file and returns it in JSON format. To be used when previewing a torrent in the UI.
- [ ] `torrents.remove` - remove one or more torrents based on info hash, optionally removing the files as well.
- [ ] `torrents.pause` - pause one or more torrents based on info hash.
- [ ] `torrents.resume` - resume one or more torrents based on info hash, optionally passing the `force` flag.
- [ ] `torrents.move` - moves one or more torrents based on info hash, optionally passing a flag to overwrite files in the destination.
- [ ] `torrents.prioritizeFiles` - prioritizes the files in a torrent.
- [ ] `torrents.renameFiles` - renames one or more files in a torrent.
- [ ] `torrents.prioritizePieces` - prioritizes the pieces in a torrent.
- [ ] `torrents.addTracker` - adds one or more trackers to a torrent
- [ ] `torrents.removeTracker` - removes one or more trackers from a torrent.

WebSocket events to implement:
- [ ] `init` - sent when a client connects to the WebSocket. Contains all the initial state needed to keep the UI in sync.
- [ ] `torrents.added` - a torrent was added.
- [ ] `torrents.removed` - a torrent was removed.
- [ ] `torrents.moved` - a torrent was moved.
- [ ] `torrents.updated` - one or more torrents had their states updated.
- [ ] `torrents.error` - one or more torrents transitioned into the error state.
- [ ] `torrents.paused` - a torrent was paused.
- [ ] `torrents.resumed` - a torrent was resumed.

Events and JSONRPC methods are subject to change.