### PR TITLE
Fix incoming connection identification and display

### DIFF
--- a/src/picotorrent/ui/models/peerlistmodel.cpp
+++ b/src/picotorrent/ui/models/peerlistmodel.cpp
@@ -127,7 +127,7 @@ void PeerListModel::GetValueByRow(wxVariant &variant, unsigned int row, unsigned
             flags << "S ";
         }
 
-        if (peer.flags & lt::peer_info::local_connection)
+        if (!(peer.flags & lt::peer_info::outgoing_connection))
         {
             flags << "I ";
         }


### PR DESCRIPTION
fix #1157
See https://libtorrent.org/reference-Core.html 
Also, `local_connection` is deprecated and should be substituted by `outgoing_connection`, too.