### PR TITLE
Add keyboard shortcuts for queue up/down

### DIFF
--- a/docs/src/keyboard-shortcuts.rst
+++ b/docs/src/keyboard-shortcuts.rst
@@ -12,4 +12,6 @@ Shortcut            Action
 :kbd:`Ctrl+A`       Select all listed torrents
 :kbd:`Del`          Remove selected torrents while keeping the downloaded data
 :kbd:`Shift+Del`    Remove selected torrents and the downloaded data
+:kbd:`Alt+Up`       Move selected torrents up the queue
+:kbd:`Alt+Down`     Move selected torrents down the queue
 =================== =========================================================

--- a/src/picotorrent/ui/torrentlistview.cpp
+++ b/src/picotorrent/ui/torrentlistview.cpp
@@ -209,6 +209,8 @@ TorrentListView::TorrentListView(wxWindow* parent, wxWindowID id, pt::UI::Models
         wxAcceleratorEntry(wxACCEL_CTRL,   int('A'),   ptID_KEY_SELECT_ALL),
         wxAcceleratorEntry(wxACCEL_NORMAL, WXK_DELETE, ptID_KEY_DELETE),
         wxAcceleratorEntry(wxACCEL_SHIFT,  WXK_DELETE, ptID_KEY_DELETE_FILES),
+        wxAcceleratorEntry(wxACCEL_ALT,    WXK_UP,     ptID_KEY_QUEUE_UP),
+        wxAcceleratorEntry(wxACCEL_ALT,    WXK_DOWN,   ptID_KEY_QUEUE_DOWN),
     };
 
     this->SetAcceleratorTable(wxAcceleratorTable(static_cast<int>(entries.size()), entries.data()));
@@ -265,6 +267,39 @@ TorrentListView::TorrentListView(wxWindow* parent, wxWindowID id, pt::UI::Models
                 wxCommandEvent(wxEVT_DATAVIEW_SELECTION_CHANGED, this->GetId()));
         },
         ptID_KEY_SELECT_ALL);
+
+    this->Bind(
+        wxEVT_MENU,
+        [&](wxCommandEvent&)
+        {
+            wxDataViewItemArray items;
+            this->GetSelections(items);
+
+            if (items.IsEmpty()) { return; }
+
+            for (wxDataViewItem& item : items)
+            {
+                m_model->GetTorrentFromItem(item)->QueueUp();
+            }
+        },
+        ptID_KEY_QUEUE_UP);
+
+    this->Bind(
+        wxEVT_MENU,
+        [&](wxCommandEvent&)
+        {
+            wxDataViewItemArray items;
+            this->GetSelections(items);
+
+            if (items.IsEmpty()) { return; }
+
+            for (wxDataViewItem& item : items)
+            {
+                m_model->GetTorrentFromItem(item)->QueueDown();
+            }
+        },
+        ptID_KEY_QUEUE_DOWN);
+
 }
 
 TorrentListView::~TorrentListView()

--- a/src/picotorrent/ui/torrentlistview.hpp
+++ b/src/picotorrent/ui/torrentlistview.hpp
@@ -29,6 +29,8 @@ namespace Models
             ptID_KEY_SELECT_ALL = wxID_HIGHEST,
             ptID_KEY_DELETE,
             ptID_KEY_DELETE_FILES,
+            ptID_KEY_QUEUE_UP,
+            ptID_KEY_QUEUE_DOWN,
         };
 
         void ShowHeaderContextMenu(wxCommandEvent&);


### PR DESCRIPTION
I don't have the tooling on my system to be able to compile this code to test it, but I think this should work (following the example of delete keyboard shortcuts).

The reason I chose Alt-Up/Down instead of Ctrl-Up/Down is because Ctrl-Up/Down seems to already be reserved by wxWidgets for moving the selection "outline" without changing the selection. There is a separate issue that you can't then use space bar (or some other key) to select the current outlined item, but that's something I'd want to be able to compile and test before opening a PR.

The use case for this keyboard shortcut is having many torrents in the list and wanting to easily push one or two up or down the queue without needing to do a right click and hover into a second menu each time.